### PR TITLE
Warn more about manual updates to answers file

### DIFF
--- a/{{ _copier_conf.answers_file }}.jinja
+++ b/{{ _copier_conf.answers_file }}.jinja
@@ -1,2 +1,2 @@
-# Changes here will be overwritten by Copier
+# Do NOT update manually; changes here will be overwritten by Copier
 {{ _copier_answers|to_nice_yaml }}


### PR DESCRIPTION

This should help PSCs that have wrong expectations about how Copier works to avoid update problems, as seen in #6.