### PR TITLE
Test python 3.6-3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        python-version:
+          - 3.6
+          - 3.7
+          - 3.8
         odoo-version:
           - 13.0
           - 14.0
@@ -23,6 +27,8 @@ jobs:
       - uses: actions/checkout@v2.3.3
       - name: Install python
         uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Python Poetry Action
         uses: abatilo/actions-poetry@v2.1.0
       - name: generate cache key PY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         python-version:
           - 3.6
-          - 3.7
           - 3.8
         odoo-version:
           - 13.0


### PR DESCRIPTION
Python 3.9 will only land in Copier v6 as seen in https://github.com/copier-org/copier/pull/294.