### PR TITLE
Add setuptools-odoo-get-requirements

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -15,7 +15,7 @@
   {%- set repo_rev.pylint = "pylint-2.5.3" %}
   {%- set repo_rev.pylint_odoo = "3.5.0" %}
   {%- set repo_rev.pyupgrade = "v2.7.2" %}
-  {%- set repo_rev.setuptools_odoo = "2.5.10" %}
+  {%- set repo_rev.setuptools_odoo = "2.6.0" %}
 {%- endif %}
 
 {#- Older versions that differ a lot have their own hardcoded templates for readability #}
@@ -122,6 +122,13 @@ repos:
     rev: {{ repo_rev.setuptools_odoo }}
     hooks:
       - id: setuptools-odoo-make-default
+      - id: setuptools-odoo-get-requirements
+        args: [
+          "--output",
+          "requirements.txt",
+          "--header",
+          "# generated from manifests external_dependencies"
+        ]
   - repo: https://gitlab.com/PyCQA/flake8
     rev: {{ repo_rev.flake8 }}
     hooks:

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -122,12 +122,14 @@ repos:
     rev: {{ repo_rev.setuptools_odoo }}
     hooks:
       - id: setuptools-odoo-make-default
+      {%- if generate_requirements_txt %}
       - id: setuptools-odoo-get-requirements
         args:
           - --output
           - requirements.txt
           - --header
           - "# generated from manifests external_dependencies"
+      {%- endif %}
   - repo: https://gitlab.com/PyCQA/flake8
     rev: {{ repo_rev.flake8 }}
     hooks:

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -123,12 +123,11 @@ repos:
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements
-        args: [
-          "--output",
-          "requirements.txt",
-          "--header",
-          "# generated from manifests external_dependencies"
-        ]
+        args:
+          - --output
+          - requirements.txt
+          - --header
+          - "# generated from manifests external_dependencies"
   - repo: https://gitlab.com/PyCQA/flake8
     rev: {{ repo_rev.flake8 }}
     hooks:

--- a/copier.yml
+++ b/copier.yml
@@ -78,6 +78,7 @@ dependency_installation_mode:
 
 generate_requirements_txt:
   default: yes
+  type: bool
   help:
     Generate requirements.txt from addons manifests and optional overrides in setup.py
     files.

--- a/copier.yml
+++ b/copier.yml
@@ -76,6 +76,12 @@ dependency_installation_mode:
   help:
     Choose how to install module dependencies. Right now, "PIP" mode is experimental.
 
+generate_requirements_txt:
+  default: yes
+  help:
+    Generate requirements.txt from addons manifests and optional overrides in setup.py
+    files.
+
 rebel_module_groups:
   type: yaml
   default: []


### PR DESCRIPTION
Generate `requirements.txt` from manifest python `external_dependencies` and `setup.py` overrides if any.

Closes #23 