### PR TITLE
Migrate prettier/prettier to prettier/pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-  - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+  - repo: https://github.com/prettier/pre-commit
+    rev: "v1.19.1"
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -9,7 +9,7 @@
   {%- set repo_rev.flake8_bugbear = "20.1.4" %}
   {%- set repo_rev.isort = "5.5.1" %}
   {%- set repo_rev.pre_commit_hooks = "v3.2.0" %}
-  {%- set repo_rev.prettier = "2.1.2" %}
+  {%- set repo_rev.prettier = "v2.1.2" %}
   {%- set repo_rev.prettier_xml = "0.12.0" %}
   {#- HACK https://github.com/OCA/pylint-odoo/issues/296#issuecomment-700317722 #}
   {%- set repo_rev.pylint = "pylint-2.5.3" %}
@@ -67,14 +67,18 @@ repos:
     rev: {{ repo_rev.black }}
     hooks:
       - id: black
-  - repo: https://github.com/prettier/prettier
+  - repo: https://github.com/prettier/pre-commit
     rev: {{ repo_rev.prettier }}
     hooks:
       - id: prettier
         name: prettier + plugin-xml
         additional_dependencies:
+          - prettier@2.1.2
           - "@prettier/plugin-xml@{{ repo_rev.prettier_xml }}"
         args:
+          - --write
+          - --list-different
+          - --ignore-unknown
           - --plugin=@prettier/plugin-xml
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: {{ repo_rev.eslint }}


### PR DESCRIPTION
Prettier installation is currently broken. See https://github.com/prettier/prettier/issues/9459

# Steps to reproduce

## Locally

If you have prettier cached, clean with `pre-commit uninstall`, and run pre-commit again. You will get an error like:
```
return code: 1
expected return code: 0
stdout: (none)
stderr:
    npm ERR! code ERESOLVE
    npm ERR! ERESOLVE unable to resolve dependency tree
    npm ERR! 
    npm ERR! While resolving: prettier@1.19.1
    npm ERR! Found: @angular/compiler@8.2.13
    npm ERR! node_modules/@angular/compiler
    npm ERR!   @angular/compiler@"8.2.13" from the root project
    npm ERR! 
    npm ERR! Could not resolve dependency:
    npm ERR! peer @angular/compiler@"^6.0.0 || ^7.0.0" from angular-estree-parser@1.1.5
    npm ERR! node_modules/angular-estree-parser
    npm ERR!   angular-estree-parser@"1.1.5" from the root project
    npm ERR! 
    npm ERR! Fix the upstream dependency conflict, or retry
    npm ERR! this command with --force, or --legacy-peer-deps
    npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
    npm ERR! 
```

## On a CI

If you have a CI system that dynamically pulls and installs prettier in each run, it will happen every time.

# Solution

Migrating from https://github.com/prettier/prettier/ to https://github.com/prettier/pre-commit/ (a mirror specifically for pre-commit) solves the problem.

Even if this is a temporary problem, there are plans to fully migrate to prettier/pre-commit in the future (https://github.com/prettier/prettier/pull/8937)

We also need to add extra `args` and `additional_dependencies` from upstream prettier in this case (https://github.com/prettier/pre-commit/issues/16#issuecomment-713501862) and add the "v" in the `ref` because the repo structure is different.

ping @pedrobaeza @sbidoul @Yajo 