### PR TITLE
Use strict mode in prettier xml plugin

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -5,4 +5,3 @@ printWidth: 88
 proseWrap: always
 semi: true
 trailingComma: "es5"
-xmlWhitespaceSensitivity: "ignore"


### PR DESCRIPTION
This will make XML files be less pretty, but also less surprising.

Fix #34.