### PR TITLE
Switch to prettier/pre-commit repo

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -67,12 +67,13 @@ repos:
     rev: {{ repo_rev.black }}
     hooks:
       - id: black
-  - repo: https://github.com/prettier/prettier
-    rev: {{ repo_rev.prettier }}
+  - repo: https://github.com/prettier/pre-commit
+    rev: v{{ repo_rev.prettier }}
     hooks:
       - id: prettier
         name: prettier + plugin-xml
         additional_dependencies:
+          - "prettier@{{ repo_rev.prettier }}"
           - "@prettier/plugin-xml@{{ repo_rev.prettier_xml }}"
         args:
           - --plugin=@prettier/plugin-xml

--- a/version-specific/13.0/.pre-commit-config.yaml
+++ b/version-specific/13.0/.pre-commit-config.yaml
@@ -23,8 +23,8 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-  - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+  - repo: https://github.com/prettier/pre-commit
+    rev: "v1.19.1"
     hooks:
       - id: prettier
   # TODO Avoid awebdeveloper/pre-commit-prettier if possible


### PR DESCRIPTION
The prettier/prettier hook is broken and incompatible with pre-commit 2.8+. Switch to prettier/pre-commit.

See also https://github.com/pre-commit/pre-commit/issues/1674