### PR TITLE
Upgrade pylint-odoo for 13.0

### DIFF
--- a/version-specific/13.0/.pre-commit-config.yaml
+++ b/version-specific/13.0/.pre-commit-config.yaml
@@ -81,17 +81,17 @@ repos:
         files: /__init__\.py$
         additional_dependencies: ["flake8-bugbear==19.8.0"]
   - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.3.1
+    rev: v2.5.3
     hooks:
       - id: pylint
         name: pylint with optional checks
         args: ["--rcfile=.pylintrc", "--exit-zero"]
         verbose: true
-        additional_dependencies: ["pylint-odoo==3.1.0"]
+        additional_dependencies: ["pylint-odoo==3.5.0"]
       - id: pylint
         name: pylint with mandatory checks
         args: ["--rcfile=.pylintrc-mandatory"]
-        additional_dependencies: ["pylint-odoo==3.1.0"]
+        additional_dependencies: ["pylint-odoo==3.5.0"]
   - repo: https://github.com/asottile/pyupgrade
     rev: v1.26.2
     hooks:


### PR DESCRIPTION
This is apparently necessary for the development status checks to work correctly.
So let's align the pylint and pylint-odoo version with the 14.0 branch.