### PR TITLE
Fix prettier installation yet again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-  - repo: https://github.com/prettier/prettier
-    rev: "1.19.1"
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.1.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -67,7 +67,7 @@ repos:
     rev: {{ repo_rev.black }}
     hooks:
       - id: black
-  - repo: https://github.com/prettier/pre-commit
+  - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v{{ repo_rev.prettier }}
     hooks:
       - id: prettier

--- a/version-specific/13.0/.pre-commit-config.yaml
+++ b/version-specific/13.0/.pre-commit-config.yaml
@@ -23,15 +23,10 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-  - repo: https://github.com/prettier/pre-commit
-    rev: "v1.19.1"
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v1.19.1
     hooks:
       - id: prettier
-  # TODO Avoid awebdeveloper/pre-commit-prettier if possible
-  # HACK https://github.com/prettier/prettier/issues/7407
-  - repo: https://github.com/awebdeveloper/pre-commit-prettier
-    rev: v0.0.1
-    hooks:
       - id: prettier
         name: prettier xml plugin
         additional_dependencies:


### PR DESCRIPTION
I hope https://github.com/prettier/pre-commit/commit/d2e9f0ce87ad6dd21deb8c48e81f92401af92988 is the last chapter of this prettiermaggeddon. At least now the official source is maintained by the pre-commit community, which has more experience on how things work for pre-commit.