### PR TITLE
Move pre-commit from Travis to GitHub actions

### DIFF
--- a/.github/workflows/pre-commit.yml.jinja
+++ b/.github/workflows/pre-commit.yml.jinja
@@ -1,0 +1,13 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0

--- a/.travis.yml.jinja
+++ b/.travis.yml.jinja
@@ -30,12 +30,6 @@ stages:
 
 jobs:
   include:
-    - stage: linting
-      name: "pre-commit"
-      install: pip install pre-commit
-      script: pre-commit run --all --show-diff-on-failure --verbose --color always
-      after_success:
-      before_install:
     {%- if rebel_module_groups %}
     {#- If there are rebel modules, we need separated test jobs and .pot generations #}
     {%- for group in rebel_module_groups %}

--- a/copier.yml
+++ b/copier.yml
@@ -12,7 +12,8 @@ _envops:
 # Other Copier configurations
 _exclude:
   - /.git
-  - /.github
+  - /.github/workflows/lint.yml
+  - /.github/workflows/test.yml
   - /.gitmodules
   - /**.pyc
   - /**.pyo


### PR DESCRIPTION
Let's try this ?

This should give a faster feedback build for those who ensure that pre-commit is green before pushing.
And this will test that the merge bot works correctly with GitHub actions.