### PR TITLE
[FIX] Upgrade maintainer-tools

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -54,7 +54,7 @@ repos:
         language: fail
         files: "\\.rej$"
   - repo: https://github.com/oca/maintainer-tools
-    rev: 1b5c7ad
+    rev: ab1d7f6
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons


### PR DESCRIPTION
Includes fix for issue when installing docutils dependency.
docutils 0.15.1-post1 has installation issues with pip.
see pypa/pip#9203 (comment)

see https://travis-ci.com/github/OCA/wms/jobs/457408267#L297