### PR TITLE
[RFR] pre-commit: prevent pyupgrade from replacing printf with str.format()

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -114,6 +114,7 @@ repos:
     rev: {{ repo_rev.pyupgrade }}
     hooks:
       - id: pyupgrade
+        args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
     rev: {{ repo_rev.isort }}
     hooks:

--- a/version-specific/13.0/.pre-commit-config.yaml
+++ b/version-specific/13.0/.pre-commit-config.yaml
@@ -87,6 +87,7 @@ repos:
     rev: v1.26.2
     hooks:
       - id: pyupgrade
+        args: ["--keep-percent-format"]
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:


### PR DESCRIPTION
So as not to encourage developers to use str.format() as there are cases where it can introduce security issues.

See https://github.com/OCA/pylint-odoo/issues/302