### PR TITLE
Fix and update prettier config

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -76,6 +76,7 @@ repos:
         name: prettier (with plugin-xml)
         additional_dependencies:
           - "prettier@{{ repo_rev.prettier }}"
+          - "@xml-tools/parser@1.0.2"
           - "@prettier/plugin-xml@{{ repo_rev.prettier_xml }}"
         args:
           - --plugin=@prettier/plugin-xml

--- a/version-specific/13.0/.pre-commit-config.yaml
+++ b/version-specific/13.0/.pre-commit-config.yaml
@@ -51,6 +51,7 @@ repos:
         name: prettier xml plugin
         additional_dependencies:
           - "prettier@1.19.1"
+          - "@xml-tools/parser@1.0.2"
           - "@prettier/plugin-xml@0.12.0"
         files: \.xml$
   - repo: https://github.com/pre-commit/mirrors-eslint

--- a/version-specific/13.0/.pre-commit-config.yaml
+++ b/version-specific/13.0/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         name: prettier xml plugin
         additional_dependencies:
           - "prettier@1.19.1"
-          - "@prettier/plugin-xml@0.7.2"
+          - "@prettier/plugin-xml@0.12.0"
         files: \.xml$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.8.0


### PR DESCRIPTION
This PR includes 2 fixes for prettier in pre-commit:

1. **Bump prettier/plugin-xml version for v13**
The plugin was not ignoring `prettier-ignore` blocks in xml files.
This feature was added in version **0.9.0**: https://github.com/prettier/plugin-xml/blob/master/CHANGELOG.md#added-1
In the latest version (**0.12.0**), this is also fixed and no major changes in formatting are introduced.
See OCA/rma@d1b73c3
(This applies the same version that is already defined for v14 branches https://github.com/OCA/oca-addons-repo-template/blob/master/.pre-commit-config.yaml.jinja#L13)
2. **Add missing prettier-xml dependency** 
After getting install errors like https://github.com/OCA/rma/runs/1733281591?check_suite_focus=true#step:4:104
looks like the prettier xml plugin depends on xml-tools/parser (see https://github.com/prettier/plugin-xml/blob/master/package.json#L22)
Adding that dependency explicitly fixes the issue.
See OCA/rma@a4b6ad8

Check the [pull request in the rma repo](https://github.com/OCA/rma/pull/198) for details.

@Tecnativa 
TT27062

ping @Yajo 