### PR TITLE
[FIX] prettier for v13 broken in mirror

### DIFF
--- a/version-specific/13.0/.pre-commit-config.yaml
+++ b/version-specific/13.0/.pre-commit-config.yaml
@@ -47,12 +47,12 @@ repos:
     rev: v1.19.1
     hooks:
       - id: prettier
-      - id: prettier
-        name: prettier xml plugin
+        name: prettier (with plugin-xml)
+        entry: prettier --write --list-different
         additional_dependencies:
           - "prettier@1.19.1"
           - "@prettier/plugin-xml@0.7.2"
-        files: \.xml$
+        files: \.(css|htm|html|js|json|jsx|less|md|scss|toml|ts|xml|yaml|yml)$
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v6.8.0
     hooks:


### PR DESCRIPTION
https://github.com/pre-commit/mirrors-prettier/issues/6 affects our repos, as it can be seen on https://github.com/OCA/social/runs/1770760744?check_suite_focus=true#step:4:110 for https://github.com/OCA/social/pull/664 and it produces random results when running `pre-commit` in different environments.

I apply here the workaround explained in that issue.

At the same time, I double-checked that we can run all prettier jobs in a single hook, so I take this chance to apply that logic, and to limit by file extensions, to make it work just like the v14 branch with #48, more predictable and efficent.