### PR TITLE
Improve isort compatibility with black

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -10,3 +10,4 @@ known_odoo=odoo
 known_odoo_addons=odoo.addons
 sections=FUTURE,STDLIB,THIRDPARTY,ODOO,ODOO_ADDONS,FIRSTPARTY,LOCALFOLDER
 default_section=THIRDPARTY
+ensure_newline_before_comments = True


### PR DESCRIPTION
Add ensure_newline_before_comments, see:
https://black.readthedocs.io/en/stable/compatible_configs.html#configuration

To trigger the rule, add a comment before some import.

