### PR TITLE
[IMP] flake8: Add F401 ignore configuration directly in .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,3 +8,5 @@ select = C,E,F,W,B,B9
 # E501: flake8 line length (covered by bugbear B950)
 # W503: line break before binary operator (black behaviour)
 ignore = E203,E501,W503
+per-file-ignores=
+    __init__.py:F401

--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -139,13 +139,7 @@ repos:
     rev: {{ repo_rev.flake8 }}
     hooks:
       - id: flake8
-        name: flake8 except __init__.py
-        exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear=={{ repo_rev.flake8_bugbear }}"]
-      - id: flake8
-        name: flake8 only __init__.py
-        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
-        files: /__init__\.py$
+        name: flake8
         additional_dependencies: ["flake8-bugbear=={{ repo_rev.flake8_bugbear }}"]
   - repo: https://github.com/PyCQA/pylint
     rev: {{ repo_rev.pylint }}

--- a/version-specific/13.0/.pre-commit-config.yaml
+++ b/version-specific/13.0/.pre-commit-config.yaml
@@ -102,13 +102,7 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
-        name: flake8 except __init__.py
-        exclude: /__init__\.py$
-        additional_dependencies: ["flake8-bugbear==19.8.0"]
-      - id: flake8
-        name: flake8 only __init__.py
-        args: ["--extend-ignore=F401"] # ignore unused imports in __init__.py
-        files: /__init__\.py$
+        name: flake8
         additional_dependencies: ["flake8-bugbear==19.8.0"]
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v2.5.3


### PR DESCRIPTION
As flake8 > 3.7.0 supports per-file-ignores options, use it directly
in .flake8 configuration file