### PR TITLE
[FIX] oca_dependencies.txt: typo on anchor id

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,1 @@
-# See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca_dependencies-txt
+# See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca-dependencies-txt


### PR DESCRIPTION
Just a minor fix.