### PR TITLE
remove oca_dependencies.txt from template

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,0 @@
-# See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca-dependencies-txt


### PR DESCRIPTION
The last change (in #57) is causing copier update merge conflicts
on all repos that touched it, essentially preventing a mass update to
the latest template.

Since this file will either go away or be auto generated, it has little value in the template anyway.