### PR TITLE
propose global owa

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,6 +14,7 @@ globals:
   moment: readonly
   odoo: readonly
   openerp: readonly
+  owl: readonly
   Promise: readonly
 
 # Styling is handled by Prettier, so we only need to enable AST rules;


### PR DESCRIPTION
Hi,

I like to propose the following change

globals:
..  
owl: readonly
..

In this way it is not necessary anymore to use the following hint in the script

/* global owl */