### PR TITLE
[IMP] eslint: Enable globals for ES6

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,6 @@
 env:
   browser: true
+  es6: true
 
 # See https://github.com/OCA/odoo-community.org/issues/37#issuecomment-470686449
 parserOptions:
@@ -15,7 +16,6 @@ globals:
   odoo: readonly
   openerp: readonly
   owl: readonly
-  Promise: readonly
 
 # Styling is handled by Prettier, so we only need to enable AST rules;
 # see https://github.com/OCA/maintainer-quality-tools/pull/618#issuecomment-558576890


### PR DESCRIPTION
Odoo support ES6 since 13.0: https://www.odoo.com/documentation/13.0/administration/install/deploy.html#supported-browsers

Option enabled: https://github.com/eslint/eslint/issues/11451#issuecomment-468022530