### PR TITLE
[ADD] Automatic PR / Issue stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,74 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 12 * * 0"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # 120+30 day stale policy for PRs
+      # * Except PRs marked as "no stale"
+      - name: Stale PRs policy
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-pr-labels: "no stale"
+          days-before-stale: 120
+          days-before-close: 30
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          remove-stale-when-updated: true
+          stale-pr-label: "stale"
+          stale-pr-message: >
+            There hasn't been any activity on this pull request in the past 4 months, so
+            it has been marked as stale and it will be closed automatically if no
+            further activity occurs in the next 30 days.
+
+            If you want this PR to never become stale, please ask a PSC member to apply
+            the "no stale" label.
+
+      # 180+30 day stale policy for open issues
+      # * Except Issues marked as "no stale"
+      - name: Stale Issues policy
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: "no stale,needs more information"
+          days-before-stale: 180
+          days-before-close: 30
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            There hasn't been any activity on this issue in the past 6 months, so it has
+            been marked as stale and it will be closed automatically if no further
+            activity occurs in the next 30 days.
+
+            If you want this issue to never become stale, please ask a PSC member to
+            apply the "no stale" label.
+
+      # 15+30 day stale policy for issues pending more information
+      # * Issues that are pending more information
+      # * Except Issues marked as "no stale"
+      - name: Needs more information stale issues policy
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-labels: "needs more information"
+          exempt-issue-labels: "no stale"
+          days-before-stale: 15
+          days-before-close: 30
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            This issue needs more information and there hasn't been any activity
+            recently, so it has been marked as stale and it will be closed automatically
+            if no further activity occurs in the next 30 days.
+
+            If you think this is a mistake, please ask a PSC member to remove the "needs
+            more information" label.


### PR DESCRIPTION
Following up on these topics:

- https://github.com/OCA/oca-github-bot/issues/10
- https://github.com/OCA/oca-github-bot/pull/67


I re-open the discussion to include this stale workflow in our repositories.

The configuration proposed is just to start the conversation, I expect it to change with whatever comes up from this thread :)

For reference: `actions/stale` docs: https://github.com/actions/stale

@sbidoul I understand from https://github.com/OCA/oca-github-bot/pull/67#issuecomment-605619867 that you've played with it on the mis-builder repository, however I don't see it active for the current default branch, did something go wrong with it or was it just forgotten?

