### PR TITLE
[FIX] pre-commit action python version

### DIFF
--- a/src/.github/workflows/pre-commit.yml
+++ b/src/.github/workflows/pre-commit.yml
@@ -10,4 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          # The pylint-odoo version we use here does not support python 3.10
+          # https://github.com/OCA/oca-addons-repo-template/issues/80
+          python-version: "3.9"
       - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
pre-commit doesn't support python 3.10 yet, so we stall the version in 3.9

cc @Tecnativa


ping @Yajo @joao-p-marques 