### PR TITLE
Use python 3.7 for Odoo 15

### DIFF
--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -11,7 +11,7 @@ on:
 {%
 set IMAGES = {
   "odoo": {
-    15.0: "ghcr.io/oca/oca-ci/py3.8-odoo15.0:latest",
+    15.0: "ghcr.io/oca/oca-ci/py3.7-odoo15.0:latest",
     14.0: "ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest",
     13.0: "ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest",
     12.0: "ghcr.io/oca/oca-ci/py3.6-odoo12.0:latest",
@@ -19,7 +19,7 @@ set IMAGES = {
     10.0: "ghcr.io/oca/oca-ci/py2.7-odoo10.0:latest",
   },
   "ocb": {
-    15.0: "ghcr.io/oca/oca-ci/py3.8-ocb15.0:latest",
+    15.0: "ghcr.io/oca/oca-ci/py3.7-ocb15.0:latest",
     14.0: "ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest",
     13.0: "ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest",
     12.0: "ghcr.io/oca/oca-ci/py3.6-ocb12.0:latest",

--- a/src/{% if ci == 'Travis' %}.travis.yml{% else %}.t2d.yml{% endif %}.jinja
+++ b/src/{% if ci == 'Travis' %}.travis.yml{% else %}.t2d.yml{% endif %}.jinja
@@ -9,7 +9,7 @@ python:
   {%- if odoo_version < 15 %}
   - "3.6"
   {%- else %}
-  - "3.8"
+  - "3.7"
   {%- endif %}
 
 addons:


### PR DESCRIPTION
Odoo now officially says python 3.7 is the minimum supported version for Odoo 15. (https://github.com/odoo/odoo/commit/794677fb6a3391379200eb2144a6ed372e89c17a)

So we test on python 3.7 in OCA, to make sure the addons we publish are compatible with Odoo deployments.
If we would not do this, there is a risk that python 3.8+ code creeps into the OCA code base, creating additional support issues.

This also addresses compatibility with travis2docker that does not support python 3.8.

Depends on 
- [ ] setuptools-odoo release https://github.com/acsone/setuptools-odoo/pull/66
- [ ] oca-github-bot update and deployment
- [x] oca-ci images build https://github.com/OCA/oca-ci/pull/14