### PR TITLE
[IMP] add support for new odoo js modules for *.esm.js files

### DIFF
--- a/src/.eslintrc.yml
+++ b/src/.eslintrc.yml
@@ -6,6 +6,12 @@ env:
 parserOptions:
   ecmaVersion: 2017
 
+overrides:
+  - files:
+      - "**/*.esm.js"
+    parserOptions:
+      sourceType: module
+
 # Globals available in Odoo that shouldn't produce errorings
 globals:
   _: readonly


### PR DESCRIPTION
Contributors must place /** @odoo-module **/ formatted js code in files with extension *.esm.js
All other *.js files will be treated as legacy js files
It will allow to support both formats

Fixes #85