### PR TITLE
Fix pre-commit errors with black

### DIFF
--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -13,5 +13,8 @@ jobs:
         with:
           # The pylint-odoo version we use here does not support python 3.10
           # https://github.com/OCA/oca-addons-repo-template/issues/80
-          python-version: "3.9"
+          # We also need to pin to an older version of python for older odoo versions
+          # where we are not using black > 21. Older black versions won't work with
+          # Python 3.9.8+, and we can't bump black without reformatting.
+          python-version: {% if odoo_version < 15 %}"3.9.7"{% else %}"3.10"{% endif %}
       - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
https://github.com/OCA/product-attribute/runs/4165598273?check_suite_focus=true#step:4:112

```
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repowzndsk7_/py_env-python3/bin/black", line 5, in <module>
    from black import patched_main
  File "/home/runner/.cache/pre-commit/repowzndsk7_/py_env-python3/lib/python3.9/site-packages/black/__init__.py", line 52, in <module>
    from typed_ast import ast3, ast27
  File "/home/runner/.cache/pre-commit/repowzndsk7_/py_env-python3/lib/python3.9/site-packages/typed_ast/ast3.py", line 40, in <module>
    from typed_ast import _ast3
ImportError: /home/runner/.cache/pre-commit/repowzndsk7_/py_env-python3/lib/python3.9/site-packages/typed_ast/_ast3.cpython-39-x86_64-linux-gnu.so: undefined symbol: _PyUnicode_DecodeUnicodeEscape
```

Appears to be an error introduced by https://github.com/python/typed_ast with Python 3.9. As explained in https://github.com/python/typed_ast#python-38, this library won't be supporting Python 3.8+

Black fixes this after release 21, but we can't bump the version in older branches without reformatting, so we need to pin the Python version instead.

@Tecnativa
TT32912

ping @Yajo @pedrobaeza @sbidoul 