### PR TITLE
[IMP] run oca-gen-addon-readme in pre-commit

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -78,6 +78,8 @@ repos:
       - id: oca-update-pre-commit-excluded-addons
       - id: oca-fix-manifest-website
         args: ["https://github.com/OCA/{{ repo_slug }}"]
+      - id: oca-gen-addon-readme
+        args: ["--repo-name", "{{ repo_slug }}", "--branch", "{{ odoo_version }}", "--no-commit"]
   - repo: https://github.com/myint/autoflake
     rev: {{ repo_rev.autoflake }}
     hooks:


### PR DESCRIPTION
This should make it clearer that changes in README.rst are lost if not
 made to the proper readme/*.rst
 
 Info @wt-io-it