### PR TITLE
Update black rev in order to include fix for https://github.com/psf/black/issues/1629

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -3,7 +3,7 @@
 
 {%- if odoo_version < 15 %}
   {%- set repo_rev.autoflake = "v1.4" %}
-  {%- set repo_rev.black = "20.8b1" %}
+  {%- set repo_rev.black = "21.4b0" %}
   {%- set repo_rev.eslint = "v7.8.1" %}
   {%- set repo_rev.flake8 = "3.8.3" %}
   {%- set repo_rev.flake8_bugbear = "20.1.4" %}


### PR DESCRIPTION
I ran into this [error](https://github.com/tafaRU/l10n-italy/runs/4289069672?check_suite_focus=true#step:4:105) related to https://github.com/psf/black/issues/1629.
In order to fix it, black needs to be updated at least to https://pypi.org/project/black/21.4b0.