### PR TITLE
Workaround issue with setuptools 60.1

### DIFF
--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -7,6 +7,10 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    env:
+      # https://github.com/pre-commit/pre-commit/issues/2178#issuecomment-1002163763
+      # https://github.com/pypa/setuptools/issues/2980
+      SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Work around `ModuleNotFoundError: No module named 'setuptools'` error that we are hitting and is apparently due to setuptools 60.1 revealing a pip bug. Links to deeper explanations are in code comments - see the diff.

I suggest waiting a couple of days before deploying this OCA-wide, to see if setuptools and virtualenv release a quick fix, until a definitive solution lands in pip later.

Can anyone check if this fix actually works ?