### PR TITLE
[FIX] false failures when detecting unreleased dependencies

### DIFF
--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -37,9 +37,10 @@ jobs:
       - run: |
           for reqfile in requirements.txt test-requirements.txt ; do
               if [ -f ${reqfile} ] ; then
+                  result=0
                   # reject non-comment lines that contain a / (i.e. URLs, relative paths)
-                  grep "^[^#].*/" ${reqfile}
-                  if [ $? -eq 0 ] ; then
+                  grep "^[^#].*/" ${reqfile} || result=$?
+                  if [ $result -eq 0 ] ; then
                       echo "Unreleased dependencies found in ${reqfile}."
                       exit 1
                   fi


### PR DESCRIPTION
The interpreter is launched with `-e` option, which makes bash fail as soon as one command fails.

The grep command will fail when there's no match. That's a valid use case, and means that there are no unreleased dependencies (or no dependencies).

See https://github.com/OCA/server-brand/runs/5123509581?check_suite_focus=true for a false negative. I attach logs here to be able to consult them after github does its GC: [logs_26.zip](https://github.com/OCA/oca-addons-repo-template/files/8031805/logs_26.zip)