### PR TITLE
[IMP] eslint: bump to escmascript 2019

### DIFF
--- a/src/.eslintrc.yml
+++ b/src/.eslintrc.yml
@@ -4,7 +4,7 @@ env:
 
 # See https://github.com/OCA/odoo-community.org/issues/37#issuecomment-470686449
 parserOptions:
-  ecmaVersion: 2017
+  ecmaVersion: 2019
 
 overrides:
   - files:


### PR DESCRIPTION
Chosen as [`MAX_ES_VERSION`](https://github.com/odoo/odoo/blob/c16bc3192/odoo/addons/test_lint/tests/test_ecmascript.py#L14) by Odoo since 14.0 [^1]

NOTE: IMO it's not worth adding version-specific templates for this (to keep 2017 version for 13.0), as the list of supported browsers hasn't changed.. it's only that we're all a bit older now