### PR TITLE
[FIX] Do not run CI jobs twice on every commit

### DIFF
--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -2,7 +2,12 @@ name: pre-commit
 
 on:
   pull_request:
+    branches:
+      - "{{ odoo_version }}*"
   push:
+    branches:
+      - "{{ odoo_version }}"
+      - "{{ odoo_version }}-ocabot-*"
 
 jobs:
   pre-commit:

--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -6,7 +6,8 @@ on:
       - "{{ odoo_version }}*"
   push:
     branches:
-      - "{{ odoo_version }}*"
+      - "{{ odoo_version }}"
+      - "{{ odoo_version }}-ocabot-*"
 
 {%
 set IMAGES = {


### PR DESCRIPTION
Because of how GitHub workflows works, two jobs were created for every
commit: one for the pull request, and one for the push. This patch
changes that behaviour.

Fixes #129