### PR TITLE
Cap python version used for pre-commit

### DIFF
--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -15,6 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+{%- if odoo_version < 11 %}
+        with:
+          python-version: "2.7"
+{%- elif odoo_version < 13 %}
+        with:
+          python-version: "3.6"
+{%- elif odoo_version < 14 %}
+        with:
+          python-version: "3.8"
+{%- endif %}
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v1


### PR DESCRIPTION
This is necessary for various reason:
- python 2 for Odoo 10
- python 3.6 for the old flake8 used by branches < 13 in MQT compatibilitly mode
- python < 3.9 for the pylint version used on branch 13.0

This fixes a regression for the 13.0 branches introduced in https://github.com/OCA/oca-addons-repo-template/pull/128 (see example failure in https://github.com/OCA/purchase-workflow/pull/1400).

