### PR TITLE
Do not ignore lib directory

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -15,7 +15,6 @@ build/
 develop-eggs/
 dist/
 eggs/
-lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
The line "lib/" at the .gitignore file is not really good. 
Because this means no directory with the name lib is added. 
As example see this pr https://github.com/OCA/wms/pull/364
At the module shopfloor_mobile_base of repo https://github.com/OCA/wms
there is the directory static/wms/src/lib and this one would be ignored