### PR TITLE
[IMP] Change pre-commit flake8 URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
       - id: trailing-whitespace
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
Currently gitlab.com (and therefore https://gitlab.com/pycqa/flake8) is banned to some countries (such as Cuba, due to the US blockade).
So, I think we can change the pre-commit configuration to use the GITHUB flake8 repository instead of the GITLAB one (https://gitlab.com/pycqa/flake8 -> https://github.com/pycqa/ flake8) since that gitlab repository is a mirror of the github one. This way we will have the original repository and also we do not affect anyone from any country in the use of pre-commit with this configuration.