### PR TITLE
Add copier question to set CI environment variables

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -156,3 +156,12 @@ github_enable_stale_action:
   type: bool
   default: yes
   help: Create GitHub 'stale' action?
+
+github_ci_extra_env:
+  type: yaml
+  default: {}
+  help: |
+    Any extra environment variables to inject into the CI
+
+    Example: {"KEY": "VALUE"}
+  when: *ci_is_github

--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -29,6 +29,7 @@ set IMAGES = {
   }
 }
 -%}
+
 jobs:
   unreleased-deps:
     runs-on: ubuntu-latest
@@ -51,6 +52,12 @@ jobs:
     runs-on: ubuntu-latest
     container: {% raw %}${{ matrix.container }}{% endraw %}
     name: {% raw %}${{ matrix.name }}{% endraw %}
+    {%- if github_ci_extra_env %}
+    env:
+      {%- for key, value in github_ci_extra_env.items() %}
+      {{ key }}: {{ value|tojson }}
+      {%- endfor %}
+    {%- endif %}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Addresses #145, adds the ability to set arbitrary additional environment variables for both Travis and GitHub... I believe the `tojson` filters are the correct solution to quote the env variable keys?

Basing the implementation on:
* https://docs.travis-ci.com/user/environment-variables/#defining-public-variables-in-travisyml
* https://docs.github.com/en/actions/learn-github-actions/environment-variables#using-contexts-to-access-environment-variable-values

cc @GlodoUK T3228