### PR TITLE
[IMP] support Odoo 16.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
             python-version: 3.8
           - odoo-version: 15.0
             python-version: 3.8
+          - odoo-version: 16.0
+            python-version: "3.10"
     steps:
       # Prepare environment
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This template allows to bootstrap and update addon repositories for these Odoo v
 - 13.0
 - 14.0
 - 15.0
+- 16.0
 
 Future versions will be added as they are released. Past versions could be added as long
 as they don't break existing branches.

--- a/copier.yml
+++ b/copier.yml
@@ -20,7 +20,7 @@ _migrations:
 
 odoo_version:
   type: float
-  default: 15.0
+  default: 16.0
   choices:
     - 10.0
     - 11.0
@@ -28,6 +28,7 @@ odoo_version:
     - 13.0
     - 14.0
     - 15.0
+    - 16.0
   help: Which Odoo version are we deploying in this branch?
 
 org_slug:

--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -12,6 +12,7 @@ on:
 {%
 set IMAGES = {
   "odoo": {
+    16.0: "ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest",
     15.0: "ghcr.io/oca/oca-ci/py3.8-odoo15.0:latest",
     14.0: "ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest",
     13.0: "ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest",
@@ -20,6 +21,7 @@ set IMAGES = {
     10.0: "ghcr.io/oca/oca-ci/py2.7-odoo10.0:latest",
   },
   "ocb": {
+    16.0: "ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest",
     15.0: "ghcr.io/oca/oca-ci/py3.8-ocb15.0:latest",
     14.0: "ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest",
     13.0: "ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest",

--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -49,7 +49,7 @@
   {%- set repo_rev.pre_commit_prettier = "v3.0.0-alpha.0" %}
   {%- set repo_rev.prettier = "2.1.2" %}
   {%- set repo_rev.prettier_xml = "1.1.0" %}
-  {%- set repo_rev.pylint_odoo = "7.0.0" %}
+  {%- set repo_rev.pylint_odoo = "7.0.1" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
   {%- set repo_rev.setuptools_odoo = "3.1.5" %}
 {%- endif %}

--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -12,7 +12,6 @@
   {%- set repo_rev.maintainer_tools = "ab1d7f6" %}
   {%- set repo_rev.nodejs = "14.13.0" %}
   {%- set repo_rev.pre_commit_hooks = "v3.2.0" %}
-  {%- set repo_rev.pre_commit_prettier = "2.1.2" %}
   {%- set repo_rev.prettier = "2.1.2" %}
   {%- set repo_rev.prettier_xml = "0.12.0" %}
   {%- set repo_rev.pylint = "v2.11.1" %}
@@ -29,7 +28,6 @@
   {%- set repo_rev.maintainer_tools = "dfba427ba03900b69e0a7f2c65890dc48921d36a" %}
   {%- set repo_rev.nodejs = "14.18.0" %}
   {%- set repo_rev.pre_commit_hooks = "v4.0.1" %}
-  {%- set repo_rev.pre_commit_prettier = "2.4.1" %}
   {%- set repo_rev.prettier = "2.4.1" %}
   {%- set repo_rev.prettier_xml = "1.1.0" %}
   {%- set repo_rev.pylint = "v2.11.1" %}
@@ -46,9 +44,8 @@
   {%- set repo_rev.maintainer_tools = "4cd2b852214dead80822e93e6749b16f2785b2fe" %}
   {%- set repo_rev.nodejs = "16.17.0" %}
   {%- set repo_rev.pre_commit_hooks = "v4.3.0" %}
-  {%- set repo_rev.pre_commit_prettier = "v3.0.0-alpha.0" %}
-  {%- set repo_rev.prettier = "2.1.2" %}
-  {%- set repo_rev.prettier_xml = "1.1.0" %}
+  {%- set repo_rev.prettier = "2.7.1" %}
+  {%- set repo_rev.prettier_xml = "2.2.0" %}
   {%- set repo_rev.pylint_odoo = "7.0.1" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
   {%- set repo_rev.setuptools_odoo = "3.1.5" %}

--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -12,13 +12,14 @@
   {%- set repo_rev.maintainer_tools = "ab1d7f6" %}
   {%- set repo_rev.nodejs = "14.13.0" %}
   {%- set repo_rev.pre_commit_hooks = "v3.2.0" %}
+  {%- set repo_rev.pre_commit_prettier = "2.1.2" %}
   {%- set repo_rev.prettier = "2.1.2" %}
   {%- set repo_rev.prettier_xml = "0.12.0" %}
   {%- set repo_rev.pylint = "v2.11.1" %}
   {%- set repo_rev.pylint_odoo = "7.0.0" %}
   {%- set repo_rev.pyupgrade = "v2.7.2" %}
   {%- set repo_rev.setuptools_odoo = "2.6.0" %}
-{%- else %}
+{%- elif odoo_version < 16 %}
   {%- set repo_rev.autoflake = "v1.4" %}
   {%- set repo_rev.black = "22.3.0" %}
   {%- set repo_rev.eslint = "v7.32.0" %}
@@ -28,12 +29,29 @@
   {%- set repo_rev.maintainer_tools = "dfba427ba03900b69e0a7f2c65890dc48921d36a" %}
   {%- set repo_rev.nodejs = "14.18.0" %}
   {%- set repo_rev.pre_commit_hooks = "v4.0.1" %}
+  {%- set repo_rev.pre_commit_prettier = "2.4.1" %}
   {%- set repo_rev.prettier = "2.4.1" %}
   {%- set repo_rev.prettier_xml = "1.1.0" %}
   {%- set repo_rev.pylint = "v2.11.1" %}
   {%- set repo_rev.pylint_odoo = "7.0.0" %}
   {%- set repo_rev.pyupgrade = "v2.29.0" %}
   {%- set repo_rev.setuptools_odoo = "3.0.3" %}
+{%- else %}
+  {%- set repo_rev.autoflake = "v1.6.1" %}
+  {%- set repo_rev.black = "22.8.0" %}
+  {%- set repo_rev.eslint = "v8.24.0" %}
+  {%- set repo_rev.flake8 = "3.9.2" %}
+  {%- set repo_rev.flake8_bugbear = "21.9.2" %}
+  {%- set repo_rev.isort = "5.10.1" %}
+  {%- set repo_rev.maintainer_tools = "4cd2b852214dead80822e93e6749b16f2785b2fe" %}
+  {%- set repo_rev.nodejs = "16.17.0" %}
+  {%- set repo_rev.pre_commit_hooks = "v4.3.0" %}
+  {%- set repo_rev.pre_commit_prettier = "v3.0.0-alpha.0" %}
+  {%- set repo_rev.prettier = "2.1.2" %}
+  {%- set repo_rev.prettier_xml = "1.1.0" %}
+  {%- set repo_rev.pylint_odoo = "7.0.0" %}
+  {%- set repo_rev.pyupgrade = "v2.38.2" %}
+  {%- set repo_rev.setuptools_odoo = "3.1.5" %}
 {%- endif %}
 
 {#- Older versions that differ a lot have their own hardcoded templates for readability #}


### PR DESCRIPTION
- Upgrade all possible pre-commit hooks.
- Use python 3.10 for CI workflows in Odoo 16 (same version as used by Odoo in their runbots)
-  Defines docker images to use to run tests with Odoo/OCB 16.0