### PR TITLE
Bump setuptools-odoo version in pre-commit

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -17,7 +17,7 @@
   {%- set repo_rev.pylint = "v2.11.1" %}
   {%- set repo_rev.pylint_odoo = "7.0.2" %}
   {%- set repo_rev.pyupgrade = "v2.7.2" %}
-  {%- set repo_rev.setuptools_odoo = "2.6.0" %}
+  {%- set repo_rev.setuptools_odoo = "3.1.8" %}
 {%- elif odoo_version < 16 %}
   {%- set repo_rev.autoflake = "v1.4" %}
   {%- set repo_rev.black = "22.3.0" %}
@@ -33,7 +33,7 @@
   {%- set repo_rev.pylint = "v2.11.1" %}
   {%- set repo_rev.pylint_odoo = "7.0.2" %}
   {%- set repo_rev.pyupgrade = "v2.29.0" %}
-  {%- set repo_rev.setuptools_odoo = "3.0.3" %}
+  {%- set repo_rev.setuptools_odoo = "3.1.8" %}
 {%- else %}
   {%- set repo_rev.autoflake = "v1.6.1" %}
   {%- set repo_rev.black = "22.8.0" %}
@@ -48,7 +48,7 @@
   {%- set repo_rev.prettier_xml = "2.2.0" %}
   {%- set repo_rev.pylint_odoo = "7.0.2" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
-  {%- set repo_rev.setuptools_odoo = "3.1.5" %}
+  {%- set repo_rev.setuptools_odoo = "3.1.8" %}
 {%- endif %}
 
 {#- Older versions that differ a lot have their own hardcoded templates for readability #}

--- a/version-specific/13.0/.pre-commit-config.yaml.jinja
+++ b/version-specific/13.0/.pre-commit-config.yaml.jinja
@@ -102,7 +102,7 @@ repos:
         name: isort except __init__.py
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.0.6
+    rev: 3.1.8
     hooks:
       - id: setuptools-odoo-make-default
       {%- if generate_requirements_txt %}

--- a/version-specific/mqt-compat/.pre-commit-config.yaml.jinja
+++ b/version-specific/mqt-compat/.pre-commit-config.yaml.jinja
@@ -25,7 +25,7 @@ repos:
       - id: oca-fix-manifest-website
         args: ["{{ repo_website }}"]
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.0.6
+    rev: 3.1.8
     hooks:
       - id: setuptools-odoo-make-default
       {%- if generate_requirements_txt %}


### PR DESCRIPTION
This is safe, and allows more complex external_dependencies_overrides.

Se example in https://github.com/OCA/server-auth/pull/438