### PR TITLE
[FIX] Change flake8 source

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -177,7 +177,7 @@ repos:
           - --header
           - "# generated from manifests external_dependencies"
       {%- endif %}
-  - repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: {{ repo_rev.flake8 }}
     hooks:
       - id: flake8


### PR DESCRIPTION
To avoid the error:

```
[INFO] Initializing environment for https://gitlab.com/PyCQA/flake8.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: could not read Username for 'https://gitlab.com': No such device or address
```

Notified in https://github.com/OCA/oca-addons-repo-template/commit/a48f386b41ff9dbdab7125e3a362b8eaae5b1af6#commitcomment-89941906

@Tecnativa