### PR TITLE
[FIX] use ubuntu 20.04 for odoo<14 ci

### DIFF
--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -11,7 +11,11 @@ on:
 
 jobs:
   pre-commit:
+{%- if odoo_version < 14 %}
+    runs-on: ubuntu-20.04
+{%- else %}
     runs-on: ubuntu-latest
+{%- endif %}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -50,7 +50,11 @@ jobs:
               fi
           done
   test:
+{%- if odoo_version < 14 %}
+    runs-on: ubuntu-20.04
+{%- else %}
     runs-on: ubuntu-latest
+{%- endif %}
     container: {% raw %}${{ matrix.container }}{% endraw %}
     name: {% raw %}${{ matrix.name }}{% endraw %}
     strategy:


### PR DESCRIPTION
this should fix builds for old Odoo versions since `ubuntu-latest` was switched to 22.04