### PR TITLE
[FIX] pre-commit: Enforce last version of pre-commit for 14

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -8,7 +8,7 @@
   {%- set repo_rev.eslint = "v7.8.1" %}
   {%- set repo_rev.flake8 = "3.8.3" %}
   {%- set repo_rev.flake8_bugbear = "20.1.4" %}
-  {%- set repo_rev.isort = "5.5.1" %}
+  {%- set repo_rev.isort = "5.12.0" %}
   {%- set repo_rev.maintainer_tools = "ab1d7f6" %}
   {%- set repo_rev.nodejs = "14.13.0" %}
   {%- set repo_rev.pre_commit_hooks = "v3.2.0" %}


### PR DESCRIPTION
Today, pre-commit on 14.0 branches started to fail:

https://github.com/OCA/account-financial-tools/actions/runs/4301519746/jobs/7498840452

