### PR TITLE
Test only supported Odoo versions

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -76,6 +76,15 @@ ci:
     - GitHub
   help: Which CI system to use ?
 
+odoo_test_flavor:
+  type: str
+  default: Both
+  choices:
+    - Odoo
+    - OCB
+    - Both
+  help: Which Odoo flavor should be used for CI tests ?
+
 travis_apt_sources:
   type: yaml
   default: []

--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -63,29 +63,41 @@ jobs:
         {%- if rebel_module_groups %}
         include:
         {%- for group in rebel_module_groups %}
+            {%- if odoo_test_flavor in ["Odoo", "Both"] %}
           - container: {{ IMAGES["odoo"][odoo_version] }}
             include: "{{ group }}"
-            makepot: "{{ github_enable_makepot | bool | lower }}"
             name: test with Odoo
+            {%- endif %}
+            {%- if odoo_test_flavor in ["OCB", "Both"] %}
           - container: {{ IMAGES["ocb"][odoo_version] }}
             include: "{{ group }}"
             name: test with OCB
+            {%- endif %}
+            makepot: "{{ github_enable_makepot | bool | lower }}"
         {%- endfor %}
+            {%- if odoo_test_flavor in ["Odoo", "Both"] %}
           - container: {{ IMAGES["odoo"][odoo_version] }}
             exclude: "{{ rebel_module_groups|join(',') }}"
-            makepot: "{{ github_enable_makepot | bool | lower }}"
             name: test with Odoo
+            {%- endif %}
+            {%- if odoo_test_flavor in ["OCB", "Both"] %}
           - container: {{ IMAGES["ocb"][odoo_version] }}
             exclude: "{{ rebel_module_groups|join(',') }}"
             name: test with OCB
+            {%- endif %}
+            makepot: "{{ github_enable_makepot | bool | lower }}"
         {%- else %}
         {#- If all modules can get along, we test and generate .pot all at once #}
         include:
+            {%- if odoo_test_flavor in ["Odoo", "Both"] %}
           - container: {{ IMAGES["odoo"][odoo_version] }}
-            makepot: "{{ github_enable_makepot | bool | lower }}"
             name: test with Odoo
+            {%- endif %}
+            {%- if odoo_test_flavor in ["OCB", "Both"] %}
           - container: {{ IMAGES["ocb"][odoo_version] }}
             name: test with OCB
+            {%- endif %}
+            makepot: "{{ github_enable_makepot | bool | lower }}"
         {%- endif %}
     services:
       postgres:


### PR DESCRIPTION
Implementing what suggested in
> The best bet is to modify the OCA CI to only use OCB. At the end, there won't be any counterpart, as there are no more Odoo updates, so if right now is green, the only chance to break it is on OCB. And we will gain less energy consumption in the builds.

_Originally posted by @pedrobaeza in https://github.com/odoo/odoo/issues/115782#issuecomment-1474877996_

The issue fixed in the linked PR is blocking many good PRs in `12.0` out there.

Here I allow to choose if tests should be executed in Odoo/OCB.

I don't know how to test this locally so I just wrote what seemed appropriate, any feedback is appreciated.
I tried removing the old `.copier-answers` from a repository and `copier /path/to/oca-addons-repo-template .` but it isn't using the edited template that I have locally.