### PR TITLE
feat: generate addons readme in pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,3 +14,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.0
+        env:
+          # Consider valid a PR that changes README fragments but doesn't
+          # change the README.rst file itself. It's not really a problem
+          # because the bot will update it anyway after merge. This way, we
+          # lower the barrier for functional contributors that want to fix the
+          # readme fragments, while still letting developers get README
+          # auto-generated (which also helps functionals when using runboat).
+          # DOCS https://pre-commit.com/#temporarily-disabling-hooks
+          SKIP: oca-gen-addon-readme

--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -109,6 +109,11 @@ repos:
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po
+      - id: oca-gen-addon-readme
+        args:
+          - --addons-dir=.
+          - --branch={{ "%.01f" | format(odoo_version) }}
+          - --repo-name={{ repo_slug }}
   - repo: https://github.com/myint/autoflake
     rev: {{ repo_rev.autoflake }}
     hooks:

--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -43,7 +43,7 @@
   {%- set repo_rev.flake8 = "3.9.2" %}
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "4cd2b852214dead80822e93e6749b16f2785b2fe" %}
+  {%- set repo_rev.maintainer_tools = "58557dd6b2c72e698dd2a0b4c5b435815e5d9d02" %}
   {%- set repo_rev.nodejs = "16.17.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
   {%- set repo_rev.pre_commit_hooks = "v4.3.0" %}
@@ -104,16 +104,17 @@ repos:
       - id: oca-update-pre-commit-excluded-addons
       - id: oca-fix-manifest-website
         args: ["{{ repo_website }}"]
-  - repo: https://github.com/OCA/odoo-pre-commit-hooks
-    rev: {{ repo_rev.odoo_pre_commit_hooks }}
-    hooks:
-      - id: oca-checks-odoo-module
-      - id: oca-checks-po
       - id: oca-gen-addon-readme
         args:
           - --addons-dir=.
           - --branch={{ "%.01f" | format(odoo_version) }}
           - --repo-name={{ repo_slug }}
+          - --if-source-changed
+  - repo: https://github.com/OCA/odoo-pre-commit-hooks
+    rev: {{ repo_rev.odoo_pre_commit_hooks }}
+    hooks:
+      - id: oca-checks-odoo-module
+      - id: oca-checks-po
   - repo: https://github.com/myint/autoflake
     rev: {{ repo_rev.autoflake }}
     hooks:

--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -43,7 +43,7 @@
   {%- set repo_rev.flake8 = "3.9.2" %}
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "58557dd6b2c72e698dd2a0b4c5b435815e5d9d02" %}
+  {%- set repo_rev.maintainer_tools = "969238e47c07d0c40573acff81d170f63245d738" %}
   {%- set repo_rev.nodejs = "16.17.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
   {%- set repo_rev.pre_commit_hooks = "v4.3.0" %}


### PR DESCRIPTION
Devs sometimes just update the `readme/*.rst` portions, relying in our nice bot that will convert that to a real `README.rst` + `index.html` after merge.

When functional people go test PRs in runboat, the 1st thing they look at is the README. That's OK because there's where the docs should explain what the module is doing.

These 2 situations are good in their own terms, but when you merge both, you get to a problem. You have to either:

- Teach functional people to review the PR code, go to the `readme/` folder and understand the `.rst` syntax and the advanced github diff tooling.
- Teach devs to remember always using the `oca-gen-addon-readme` before pushing the PR, so functionals can review the README in a more human-friendly fashion.

None of these is a good solution. Both add manual and complex steps to the contribution workflow.

Quoting from [OCA blog][1]:

> The Board are working on these Major Projects for 2023:
> Improve Contributor onboarding journey, leverage delegates
> - Including Functional Consultants

This PR goes along with those goals. By moving the readme generation into a pre-commit hook:

1. The dev just needs to stage -> commit -> re-stage -> re-commit. Just like always.
2. The functionals have a nicely rendered README available right from the Odoo UI. That's the UI a functional needs to know deeply (not Github's).

@moduon

[1]: https://odoo-community.org/blog/news-updates-1/oca-newsletter-1-2023-136