### PR TITLE
[FIX] pre-commit: bump nodejs version for Odoo 15

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -26,7 +26,7 @@
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.isort = "5.12.0" %}
   {%- set repo_rev.maintainer_tools = "dfba427ba03900b69e0a7f2c65890dc48921d36a" %}
-  {%- set repo_rev.nodejs = "14.18.0" %}
+  {%- set repo_rev.nodejs = "14.19.0" %}
   {%- set repo_rev.pre_commit_hooks = "v4.0.1" %}
   {%- set repo_rev.prettier = "2.4.1" %}
   {%- set repo_rev.prettier_xml = "1.1.0" %}


### PR DESCRIPTION
Fixes an issue with the download of nodejs 14.18.0 that causes all pre-commit runs to fail

See: #193 