### PR TITLE
[FIX] Make Python version explicit in pre-commit workflow

### DIFF
--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -25,9 +25,12 @@ jobs:
 {%- elif odoo_version < 13 %}
         with:
           python-version: "3.6"
-{%- elif odoo_version < 14 %}
+{%- elif odoo_version < 15 %}
         with:
           python-version: "3.8"
+{%- elif odoo_version <= 16 %}
+        with:
+          python-version: "3.10"
 {%- endif %}
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV


### PR DESCRIPTION
Recently (or recently enough that I've just begun noticing it), the nodeenv dependency had troubles installing. Sometimes. It wasn't very reliably failing.

This is related to <https://github.com/ekalinin/nodeenv/issues/328>.

By explicitly setting the Python version to something <=3.10, we can safely pretend the problem doesn't exist.

Ideally the Python versions match up to the ones used in test.yml, but they don't, and I fear it might be too intrusive to fix that in this commit.