### PR TITLE
Upgrade actions/checkout to v3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.0

--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
 {%- endif %}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
 {%- if odoo_version < 11 %}
         with:

--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Detect unreleased dependencies
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           for reqfile in requirements.txt test-requirements.txt ; do
               if [ -f ${reqfile} ] ; then
@@ -123,7 +123,7 @@ jobs:
       {%- endfor %}
     {%- endif %}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Install addons and dependencies


### PR DESCRIPTION
Fixes deprecated warning on actions/checkout in GitHub actions:


> Detect unreleased dependencies
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For  more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

