### PR TITLE
Support Python 2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,41 @@ on:
     types: [created]
 
 jobs:
+  test_python27:
+    runs-on: ubuntu-20.04
+    container:
+      image: python:2.7.18-buster
+    steps:
+      # Prepare environment
+      - uses: actions/checkout@v3
+
+      # Make Python 3.6 also available when testing Python 2.7.
+      # It is required by `pipx`
+      - name: Install python3.6
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.6
+
+      - name: Install pipx
+        run: pip3 install pipx
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      # Let tests issue git commits
+      - run: git config --global user.name CI
+      - run: git config --global user.email CI@GITHUB
+
+      # Run all tests
+      - run: poetry install
+      - run: poetry run pytest --color yes
+        env:
+          SELECTED_ODOO_VERSIONS: 10.0
   test:
     runs-on: ${{matrix.machine}}
     strategy:
       matrix:
         include:
-          - odoo-version: 10.0
-            python-version: 2.7
-            machine: ubuntu-20.04
           - odoo-version: 11.0
             python-version: 3.6
             machine: ubuntu-20.04
@@ -39,13 +66,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install poetry
         run: pipx install poetry
-
-      # Make Python 3.6 also available when testing Python 2.7.
-      - name: Install python3.6
-        if: ${{ matrix.python-version == 2.7 }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.6
 
       # Install specific alternate python versions required by hooks
       - name: Install python

--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -16,18 +16,21 @@ jobs:
 {%- else %}
     runs-on: ubuntu-22.04
 {%- endif %}
+{%- if odoo_version < 11 %}
+    container:
+      image: python:2.7.18-buster
+{%- endif %}
     steps:
       - uses: actions/checkout@v3
+{%- if odoo_version >= 11 %}
       - uses: actions/setup-python@v2
-{%- if odoo_version < 11 %}
-        with:
-          python-version: "2.7"
-{%- elif odoo_version < 13 %}
+{%- if odoo_version < 13 %}
         with:
           python-version: "3.6"
 {%- elif odoo_version < 14 %}
         with:
           python-version: "3.8"
+{%- endif %}
 {%- endif %}
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV


### PR DESCRIPTION
>Tests fail because we lost support for Python 2.7
>
>> The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672

_Originally posted by @StefanRijnhart in https://github.com/OCA/oca-addons-repo-template/issues/198#issuecomment-1597034517_

Fix the above issue, and the same issue also in Repositories using this template