### PR TITLE
[IMP] Update pre-commit pylint_odoo version

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -33,7 +33,7 @@
   {%- set repo_rev.prettier = "2.4.1" %}
   {%- set repo_rev.prettier_xml = "1.1.0" %}
   {%- set repo_rev.pylint = "v2.11.1" %}
-  {%- set repo_rev.pylint_odoo = "7.0.2" %}
+  {%- set repo_rev.pylint_odoo = "7.0.5" %}
   {%- set repo_rev.pyupgrade = "v2.29.0" %}
   {%- set repo_rev.setuptools_odoo = "3.1.8" %}
 {%- else %}


### PR DESCRIPTION
When adding a field with groups and that also belong to a domain, it is necessary to duplicate the field in the view to avoid an error. This was solved for pylint_odoo 7.0.5, but the template is not updated. So updating the version will prevent similar problems with future v16 works.

References:
https://github.com/OCA/odoo-pre-commit-hooks/issues/10
https://github.com/OCA/oca-addons-repo-template/issues/195

ping @pedrobaeza 