### PR TITLE
fix: pylint-odoo v8 configuration options ignored

### DIFF
--- a/src/.pylintrc-mandatory.jinja
+++ b/src/.pylintrc-mandatory.jinja
@@ -6,12 +6,21 @@ load-plugins=pylint_odoo
 score=n
 
 [ODOOLINT]
+{%- if odoo_version < 16 %}
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest_required_authors={{ org_name }}
 manifest_required_keys=license
 manifest_deprecated_keys=description,active
 license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
 valid_odoo_versions={{ odoo_version }}
+{%- else %}
+readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
+manifest-required-authors={{ org_name }}
+manifest-required-keys=license
+manifest-deprecated-keys=description,active
+license-allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+valid-odoo-versions={{ odoo_version }}
+{%- endif %}
 
 [MESSAGES CONTROL]
 disable=all


### PR DESCRIPTION
Under OCA/pylint-odoo#426, underscores were replaced with dashes for configuration options, when pylint-odoo was bumped in oca-addons-repo-template#198 this change was not taken into account.

I *think* this is the best way to deal with this?