### PR TITLE
[FIX] eslint luxon global variable

### DIFF
--- a/src/{% if odoo_version > 12 %}.eslintrc.yml{% endif %}
+++ b/src/{% if odoo_version > 12 %}.eslintrc.yml{% endif %}
@@ -22,6 +22,7 @@ globals:
   odoo: readonly
   openerp: readonly
   owl: readonly
+  luxon: readonly
 
 # Styling is handled by Prettier, so we only need to enable AST rules;
 # see https://github.com/OCA/maintainer-quality-tools/pull/618#issuecomment-558576890


### PR DESCRIPTION
luxon is available globally so no eslint errors should be thrown when importing from it like in

```js
const {DateTime} = luxon
```

Example: https://github.com/OCA/web/blob/84ffe96670ecb3c9c6d06b3c4a0bbee83e84d889/web_time_range_menu_custom/static/src/js/date_selector.esm.js#L9