### PR TITLE
fix: remove .gitignore symlink

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,0 @@
-../.gitignore

--- a/src/.gitignore.jinja
+++ b/src/.gitignore.jinja
@@ -1,0 +1,1 @@
+{%- include ".gitignore" -%}


### PR DESCRIPTION
Github started yelling about this on pushes:

```
remote: warning: object 65d1b858f5be86bfce970ad2d62f9da069d2dc0e: gitignoreSymlink: .gitignore is a symlink
remote: warning: object 42ebddb6035aab3e90519f5b7399ed21d136accb: gitignoreSymlink: .gitignore is a symlink
remote: warning: object 03fa2ace7a66607d13abf9f1a4ea8467d9c4f86d: gitignoreSymlink: .gitignore is a symlink
remote: warning: object ef8578ca083d6385d8372f72eb3b6003e7fe0444: gitignoreSymlink: .gitignore is a symlink
remote: warning: object f0a868987d1845511053b3f8a96ce54de503edb0: gitignoreSymlink: .gitignore is a symlink
remote: warning: object cb5a03f27c273dac6c052e5b55333aa6596d664b: gitignoreSymlink: .gitignore is a symlink
remote: warning: object dd98cb3fbaaa95349b1516c6f8a2773c2127fb79: gitignoreSymlink: .gitignore is a symlink
remote: warning: object 6221d3a6badedb2d4795f0de0098a16d622e90b5: gitignoreSymlink: .gitignore is a symlink
remote: warning: object 9fdd045465094feb23ed1bb86ee93ece1b35c1e1: gitignoreSymlink: .gitignore is a symlink
```