### PR TITLE
Generate README for selected Organization

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -108,6 +108,7 @@ repos:
         args:
           - --addons-dir=.
           - --branch={{ "%.01f" | format(odoo_version) }}
+          - --org-name={{ org_slug }}
           - --repo-name={{ repo_slug }}
           - --if-source-changed
   - repo: https://github.com/OCA/odoo-pre-commit-hooks


### PR DESCRIPTION
Before this change, links in the README are always generated as `OCA/repo_slug` despite the user may have answered a different organization to the question
> What's the organization slug? If you are creating https://github.com/OCA/server-tools, then write "OCA" here.