### PR TITLE
Don't bother non-technical authors with minor formatting issues in readme fragments

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -77,6 +77,8 @@ exclude: |
   /static/(src/)?lib/|
   # Repos using Sphinx to generate docs don't need prettying
   ^docs/_templates/.*\.html$|
+  # Don't bother non-technical authors with formatting issues in docs
+  readme/.*\.(rst|md)$|
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:


### PR DESCRIPTION
I propose to exclude `readme/` fragments from linters.

As long as the `README.rst` generator accepts them and produces valid `.rst` (which is checked upon `ocabot merge`), we should not bother non technical authors with overly strict formatting issues of readme fragments.
