### PR TITLE
[FIX] github pre-commit action: pin python version to 3.11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
+        with:
+          python-version: "3.11"
       - uses: pre-commit/action@v2.0.0

--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -28,6 +28,9 @@ jobs:
 {%- elif odoo_version < 14 %}
         with:
           python-version: "3.8"
+{%- else %}
+        with:
+          python-version: "3.11"
 {%- endif %}
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV


### PR DESCRIPTION
Recently I had problems with passing pre-commit, since github action started to use Python 3.12

When running pre-commit action on 3.12 you get following errors:

```
autoflake................................................................Failed
- hook id: autoflake
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo7lg_lq3_/py_env-python3/bin/autoflake", line 5, in <module>
    from autoflake import main
  File "/home/runner/.cache/pre-commit/repo7lg_lq3_/py_env-python3/lib/python3.12/site-packages/autoflake.py", line 32, in <module>
    import distutils.sysconfig
ModuleNotFoundError: No module named 'distutils'
```

```
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repotxkzga5l/py_env-python3/bin/flake8", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/.cache/pre-commit/repotxkzga5l/py_env-python3/lib/python3.12/site-packages/flake8/main/cli.py", line 22, in main
    app.run(argv)
  File "/home/runner/.cache/pre-commit/repotxkzga5l/py_env-python3/lib/python3.12/site-packages/flake8/main/application.py", line 363, in run
    self._run(argv)
  File "/home/runner/.cache/pre-commit/repotxkzga5l/py_env-python3/lib/python3.12/site-packages/flake8/main/application.py", line 350, in _run
    self.initialize(argv)
  File "/home/runner/.cache/pre-commit/repotxkzga5l/py_env-python3/lib/python3.12/site-packages/flake8/main/application.py", line 330, in initialize
    self.find_plugins(config_finder)
  File "/home/runner/.cache/pre-commit/repotxkzga5l/py_env-python3/lib/python3.12/site-packages/flake8/main/application.py", line 153, in find_plugins
    self.check_plugins = plugin_manager.Checkers(local_plugins.extension)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repotxkzga5l/py_env-python3/lib/python3.12/site-packages/flake8/plugins/manager.py", line 356, in __init__
    self.manager = PluginManager(
                   ^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repotxkzga5l/py_env-python3/lib/python3.12/site-packages/flake8/plugins/manager.py", line 238, in __init__
    self._load_entrypoint_plugins()
  File "/home/runner/.cache/pre-commit/repotxkzga5l/py_env-python3/lib/python3.12/site-packages/flake8/plugins/manager.py", line 254, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'EntryPoints' object has no attribute 'get'
```

Pinning to 3.11 fixes errors above.