### PR TITLE
Revert "feat: generate addons readme in pre-commit"

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -114,13 +114,6 @@ repos:
       - id: oca-update-pre-commit-excluded-addons
       - id: oca-fix-manifest-website
         args: ["{{ repo_website }}"]
-      - id: oca-gen-addon-readme
-        args:
-          - --addons-dir=.
-          - --branch={{ "%.01f" | format(odoo_version) }}
-          - --org-name={{ org_slug }}
-          - --repo-name={{ repo_slug }}
-          - --if-source-changed
       {%- if use_pyproject_toml and generate_requirements_txt %}
       - id: oca-gen-external-dependencies
       {%- endif %}


### PR DESCRIPTION
This reverts commit a1551e5d312fc8c48571b124e02c91c2c19d671a.

Rational: The call of oca-gen-addon-readme will generate conflicts in the readme.rst file when 2 PRs modify the same module. See https://github.com/OCA/oca-addons-repo-template/pull/190#issuecomment-1784116516