### PR TITLE
[FIX] Only execute the PO file review for files inside a 18n folder

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -120,6 +120,7 @@ repos:
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po
+        files: '/i18n/[a-zA-Z0-9_]*\.(po|pot)$'
   {%- if not use_ruff %}
   - repo: https://github.com/myint/autoflake
     rev: {{ repo_rev.autoflake }}


### PR DESCRIPTION
Applies the fix for https://github.com/OCA/odoo-pre-commit-hooks/pull/90

tested on https://github.com/OCA/connector/pull/469