### PR TITLE
Enable ruff line too long check

### DIFF
--- a/src/{% if use_ruff %}.ruff.toml{% endif%}.jinja
+++ b/src/{% if use_ruff %}.ruff.toml{% endif%}.jinja
@@ -9,6 +9,7 @@ fix = true
 extend-select = [
     "B",
     "C90",
+    "E501"  # line too long (default 88)
     "I",  # isort
     {%- if odoo_version >= 15.0 %}
     "UP",  # pyupgrade


### PR DESCRIPTION
It is disabled by default because ruff-format makes a best effort attempt to satisfy it and may fail otherwise.

It should fine to enable it as it was with flake8 (the default is 88).

See https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules for more information.