### PR TITLE
[FIX] add missing comma

### DIFF
--- a/src/{% if use_ruff %}.ruff.toml{% endif%}.jinja
+++ b/src/{% if use_ruff %}.ruff.toml{% endif%}.jinja
@@ -9,7 +9,7 @@ fix = true
 extend-select = [
     "B",
     "C90",
-    "E501"  # line too long (default 88)
+    "E501",  # line too long (default 88)
     "I",  # isort
     {%- if odoo_version >= 15.0 %}
     "UP",  # pyupgrade


### PR DESCRIPTION
Add missing comma causing ruff to fail :
```
ruff failed
  Cause: Failed to parse `.ruff.toml`: TOML parse error at line 10, column 5
   |
10 |     "I",  # isort
   |     ^
invalid array
expected `]`
```