### PR TITLE
[FIX] Do not apply XML new style checks to 14.0

### DIFF
--- a/src/{% if odoo_version <= 14 %}.oca_hooks.cfg{% endif %}
+++ b/src/{% if odoo_version <= 14 %}.oca_hooks.cfg{% endif %}
@@ -1,0 +1,2 @@
+[MESSAGES_CONTROL]
+disable=xml-deprecated-data-node,xml-deprecated-tree-attribute


### PR DESCRIPTION
This will about most of the failing updates to 14.0 dotfiles, since the current pre-commit is running new checks not verified on the previous pre-commit version.

Example where this was verified and got a green build:
https://github.com/OCA/product-attribute/pull/1440

cc @etobella @sbidoul @moylop260 