### PR TITLE
[FIX] prevent a warning message.

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -86,7 +86,7 @@ exclude: |
   # Ignore build and dist directories in addons
   /build/|/dist/|
   # Ignore test files in addons
-  /tests/samples/*|
+  /tests/samples/.*|
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:


### PR DESCRIPTION
Rational : once https://github.com/OCA/oca-addons-repo-template/pull/240 has been merged, there is a warning when we run ``pre-commit run -a`` in a repo that uses that template.

```
[WARNING] The top-level 'exclude' field is a regex, not a glob -- matching '/*' probably isn't what you want here
```

This commit removes the warning.

CC : original commiters @tuantrantg / reviewers : @pedrobaeza, @yajo, @simahawk, @carmenbianca