### PR TITLE
fix(codecov): continue on error

### DIFF
--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -146,6 +146,7 @@ jobs:
         run: oca_run_tests
       {%- if github_enable_codecov %}
       - uses: codecov/codecov-action@v4
+        continue-on-error: true
         with:
           token: {{"${{ secrets.CODECOV_TOKEN }}"}}
       {%- endif %}


### PR DESCRIPTION
This should help in the future to protect against situations like https://github.com/OCA/oca-addons-repo-template/issues/250, when Codecov suddenly changes something, starts to fail and becomes blocking for everybody here.