### PR TITLE
[FIX] 15/16/17: Removed first line break on pre-commit template

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -66,7 +66,7 @@
   {%- include "version-specific/%s/.pre-commit-config.yaml.jinja" % odoo_version %}
 
 {#- Newer versions without hacks are rendered here directly #}
-{%- else %}
+{%- else -%}
 exclude: |
   (?x)
   # NOT INSTALLABLE ADDONS


### PR DESCRIPTION
Hello,

When using v15/v16/v17, It creates .pre-commit-config.yaml with a line break on the first line. 

If you use pre-commit It fails at the first attempt because this line gets removed.

With this change, the file is created correctly

Thank you!