### PR TITLE
[FIX] Support ecmaVersion 2022

### DIFF
--- a/src/{% if odoo_version > 12 %}.eslintrc.yml{% endif %}.jinja
+++ b/src/{% if odoo_version > 12 %}.eslintrc.yml{% endif %}.jinja
@@ -4,7 +4,7 @@ env:
 
 # See https://github.com/OCA/odoo-community.org/issues/37#issuecomment-470686449
 parserOptions:
-  ecmaVersion: 2019
+  ecmaVersion: {% if odoo_version < 17 %}2019{% else %}2022{% endif %}
 
 overrides:
   - files:


### PR DESCRIPTION
Odoo officially supports ecmaVersion 2022 from v17: https://github.com/odoo/odoo/blame/9a11717c17b860ec2f1b2e228517c0d3945c474a/addons/web/tooling/_eslintrc.json#L9

Possible fixes:

- Support it globally
- Make an special template for Odoo >= 17

What do you think?