### PR TITLE
[IMP] Include .pkg in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ var/
 *.egg
 *.eggs
 
+# Windows installers
+*.msi
+
 # Debian packages
 *.deb
 
@@ -33,6 +36,7 @@ var/
 
 # MacOS packages
 *.dmg
+*.pkg
 
 # Installer logs
 pip-log.txt


### PR DESCRIPTION
It seems that's the package format for MacOS pandoc library:

https://github.com/OCA/credit-control/commit/2e2adf92d15a6b90b7ab15ed61056b85ffb2b3f2