### PR TITLE
[FIX] oca-check-po: don't check po-pretty-format

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -159,6 +159,8 @@ repos:
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po
+        args:
+          - --disable=po-pretty-format
   {%- if not use_ruff %}
   - repo: https://github.com/myint/autoflake
     rev: {{ repo_rev.autoflake }}


### PR DESCRIPTION
Don't enforce po pretty format that raises if a msgid has the same value as the msgstr. As weblate has those values, it will lead to problems.

Moreover, in some languages, some translations can have the same value as the original language.

@moylop260 @sbidoul 

Related to : https://github.com/OCA/server-env/pull/204


Needed for v18.