### PR TITLE
Revert eslint upgrade

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -58,7 +58,7 @@
 {%- else %}
   {%- set repo_rev.autoflake = "v1.6.1" %}
   {%- set repo_rev.black = "22.8.0" %}
-  {%- set repo_rev.eslint = "v9.11.1" %}
+  {%- set repo_rev.eslint = "v8.24.0" %}
   {%- set repo_rev.flake8 = "3.9.2" %}
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.isort = "5.12.0" %}


### PR DESCRIPTION
The configuration file format has changed, andit does work well with pre-commit.

So we keep the previous version for now.