### PR TITLE
[FIX] ruff: ignore printf-string-formatting of rule up031

### DIFF
--- a/src/{% if use_ruff %}.ruff.toml{% endif%}.jinja
+++ b/src/{% if use_ruff %}.ruff.toml{% endif%}.jinja
@@ -18,6 +18,7 @@ extend-select = [
     "{{ rule }}",
     {%- endfor %}
 ]
+ignore = ["UP031"]
 exclude = ["setup/*"]
 
 [format]


### PR DESCRIPTION
When not using Ruff, pre-commit prevents pyupgrade from replacing printf with str.format() (https://github.com/OCA/oca-addons-repo-template/pull/49). 

Using Ruff this rule is not being ignored. This commit modifies the Ruff configuration adding an ignore rule for `UP031`.