### PR TITLE
[FIX] pre-commit: update pylint odoo to enable valid-odoo-versions key for v18

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -38,7 +38,7 @@
   {%- set repo_rev.pyupgrade = "v2.29.0" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.1.8" %}
-{%- elif odoo_version < 18 %}
+{%- elif odoo_version < 17 %}
   {%- set repo_rev.autoflake = "v1.6.1" %}
   {%- set repo_rev.black = "22.8.0" %}
   {%- set repo_rev.eslint = "8.24.0" %}
@@ -52,6 +52,23 @@
   {%- set repo_rev.prettier = "2.7.1" %}
   {%- set repo_rev.prettier_xml = "2.2.0" %}
   {%- set repo_rev.pylint_odoo = "v8.0.19" %}
+  {%- set repo_rev.pyupgrade = "v2.38.2" %}
+  {%- set repo_rev.ruff = "v0.1.3" %}
+  {%- set repo_rev.setuptools_odoo = "3.1.8" %}
+{%- elif odoo_version < 18 %}
+  {%- set repo_rev.autoflake = "v1.6.1" %}
+  {%- set repo_rev.black = "22.8.0" %}
+  {%- set repo_rev.eslint = "8.24.0" %}
+  {%- set repo_rev.flake8 = "3.9.2" %}
+  {%- set repo_rev.flake8_bugbear = "21.9.2" %}
+  {%- set repo_rev.isort = "5.12.0" %}
+  {%- set repo_rev.maintainer_tools = "d5fab7ee87fceee858a3d01048c78a548974d935" %}
+  {%- set repo_rev.nodejs = "16.17.0" %}
+  {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
+  {%- set repo_rev.pre_commit_hooks = "v4.3.0" %}
+  {%- set repo_rev.prettier = "2.7.1" %}
+  {%- set repo_rev.prettier_xml = "2.2.0" %}
+  {%- set repo_rev.pylint_odoo = "v9.0.4" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.1.8" %}
@@ -69,14 +86,10 @@
   {%- set repo_rev.pre_commit_hooks = "v4.6.0" %}
   {%- set repo_rev.prettier = "3.3.3" %}
   {%- set repo_rev.prettier_xml = "3.4.1" %}
-  {%- set repo_rev.pylint_odoo = "v9.1.2" %}
+  {%- set repo_rev.pylint_odoo = "v9.1.3" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
   {%- set repo_rev.ruff = "v0.6.8" %}
   {%- set repo_rev.setuptools_odoo = "3.1.8" %}
-{%- endif %}
-
-{%- if odoo_version > 16 %}
-  {%- set repo_rev.pylint_odoo = "v9.0.4" %}
 {%- endif %}
 
 {#- Older versions that differ a lot have their own hardcoded templates for readability #}


### PR DESCRIPTION
Without updating the linter and using `valid-odoo-versions=18.0`, pylint_odoo (mandatory check) passes green but without checking any rules.

pylint-odoo unfortunately doesn't notify the user of 18.0 not being supported in v9.1.2. Support was added in v9.1.3 (https://github.com/OCA/pylint-odoo/compare/v9.1.2...v9.1.3) in PR https://github.com/OCA/pylint-odoo/pull/497

Example with `valid-odoo-versions=18.0` and `pylint-odoo==v1.9.2`:
<img width="652" alt="Screenshot 2024-10-11 at 13 54 37" src="https://github.com/user-attachments/assets/d6a7aba8-6359-4546-9a9e-a7b2a441bf1b">

Working example with `valid-odoo-versions=18.0` and `pylint-odoo==v1.9.3`:
<img width="1404" alt="Screenshot 2024-10-11 at 13 53 57" src="https://github.com/user-attachments/assets/74673feb-87f9-4cad-9eec-3a539dadc3db">

Builds on: https://github.com/OCA/oca-addons-repo-template/pull/272

pylint_odoo's version was also being overridden. This commit fixes that by adding a new v17 section.