### PR TITLE
[IMP] Use specific python version for a set of hooks

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -3,6 +3,7 @@
 
 {#- '<15' only affects to 14.0 #}
 {%- if odoo_version < 15 %}
+  {%- set repo_rev.python_version = "python3.8" %}
   {%- set repo_rev.autoflake = "v1.4" %}
   {%- set repo_rev.black = "22.3.0" %}
   {%- set repo_rev.eslint = "7.8.1" %}
@@ -21,6 +22,7 @@
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.1.8" %}
 {%- elif odoo_version < 16 %}
+  {%- set repo_rev.python_version = "python3.8" %}
   {%- set repo_rev.autoflake = "v1.4" %}
   {%- set repo_rev.black = "22.3.0" %}
   {%- set repo_rev.eslint = "7.32.0" %}
@@ -39,6 +41,7 @@
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.1.8" %}
 {%- elif odoo_version < 17 %}
+  {%- set repo_rev.python_version = "python3.10" %}
   {%- set repo_rev.autoflake = "v1.6.1" %}
   {%- set repo_rev.black = "22.8.0" %}
   {%- set repo_rev.eslint = "8.24.0" %}
@@ -56,6 +59,7 @@
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.1.8" %}
 {%- elif odoo_version < 18 %}
+  {%- set repo_rev.python_version = "python3.10" %}
   {%- set repo_rev.autoflake = "v1.6.1" %}
   {%- set repo_rev.black = "22.8.0" %}
   {%- set repo_rev.eslint = "8.24.0" %}
@@ -73,6 +77,7 @@
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.1.8" %}
 {%- else %}
+  {%- set repo_rev.python_version = "python3.12" %}
   {%- set repo_rev.autoflake = "v1.6.1" %}
   {%- set repo_rev.black = "22.8.0" %}
   {%- set repo_rev.eslint = "9.12.0" %}
@@ -124,7 +129,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: "{{ repo_rev.python_version }}"
   node: "{{ repo_rev.nodejs }}"
 repos:
   - repo: local


### PR DESCRIPTION
Pin the python version per Odoo version.

e.g.: as each local environment can be different, force the python version to avoid problems with incompatible hooks versions

@sbidoul 