### PR TITLE
[FIX] Add checklog-odoo configuration to not fail when there are no tests in the repo

### DIFF
--- a/src/{% if enable_checklog_odoo %}checklog-odoo.cfg{% endif %}
+++ b/src/{% if enable_checklog_odoo %}checklog-odoo.cfg{% endif %}
@@ -1,0 +1,3 @@
+[checklog-odoo]
+ignore=
+    WARNING.* 0 failed, 0 error\(s\).*


### PR DESCRIPTION
to prevent CI to be red for valid PRs, if no test are executed.

Trouble introduced since https://github.com/OCA/oca-addons-repo-template/pull/271 on V18 branch

Impact many PRs, specially when the repos is empty, that occures a lot at the beginning of a new revision (like here, in V18).
for the time being, a lot of PRs are red for no reason,  which slows down the merge process, and results in a poor user experience for new or occasional contributors.

This PR implement the @StefanRijnhart [suggestion](https://github.com/OCA/account-financial-tools/pull/1963#issuecomment-2503249457).