### PR TITLE
Bump version of actions/cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.0" # Just a placeholder; the real version is the git tag
 description = "Template for OCA addon repos"
 authors = ["Odoo Community Association (OCA)"]
 license = "MIT"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9.0"

--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -34,7 +34,7 @@ jobs:
 {%- endif %}
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: {% raw %}pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}{% endraw %}


### PR DESCRIPTION
Current version will be obsolete after 1st of February.

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down