### PR TITLE
[FIX] Use latest maintainer-tools for 18.0

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -81,7 +81,7 @@
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.globals = "16.0.0" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "bf9ecb9938b6a5deca0ff3d870fbd3f33341fded" %}
+  {%- set repo_rev.maintainer_tools = "b89f767503be6ab2b11e4f50a7557cb20066e667" %}
   {%- set repo_rev.nodejs = "22.9.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.33" %}
   {%- set repo_rev.pre_commit_hooks = "v4.6.0" %}


### PR DESCRIPTION
Recent commit fixes error, that raises when creating addons directory from template

https://github.com/OCA/maintainer-tools/commit/b89f767503be6ab2b11e4f50a7557cb20066e667