### PR TITLE
[IMP] Add QUnit as global in eslint.config for >=18.0

### DIFF
--- a/src/{% if odoo_version >= 18 %}eslint.config.cjs{% endif %}
+++ b/src/{% if odoo_version >= 18 %}eslint.config.cjs{% endif %}
@@ -17,6 +17,7 @@ const config = [{
             openerp: "readonly",
             owl: "readonly",
             luxon: "readonly",
+            QUnit: "readonly",
             ...globals.browser,
         },
 


### PR DESCRIPTION
In >= 18.0 QUnit is added as global https://github.com/odoo/odoo/blob/4b6770ec30bd00213674df2b075c77f33a0e65d9/addons/web/static/src/%40types/libs.d.ts#L5

Added the key on globals to avoid no-undef linter error.