### PR TITLE
[IMP] Add test.js on eslint as modules in order to make it work with hoot

### DIFF
--- a/src/{% if odoo_version >= 18 %}eslint.config.cjs{% endif %}
+++ b/src/{% if odoo_version >= 18 %}eslint.config.cjs{% endif %}
@@ -194,7 +194,7 @@ const config = [{
     },
 
 }, {
-    files: ["**/*.esm.js"],
+    files: ["**/*.esm.js", "**/*test.js"],
 
     languageOptions: {
         ecmaVersion: 2024,


### PR DESCRIPTION
It was necessary to do it manually on automation_oca to make it work

https://github.com/OCA/automation/pull/25/commits/b55c25a780ddc21bd338c01a583afecec6b2213d#diff-ade92dc557e1c37f3e97d3323edfba82ec5ae154ff4325ddd06962631a5c2666L194
