### PR TITLE
feat: Set merge strategy test-requirements to union

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test-requirements.txt merge=union


### PR DESCRIPTION
Motivation for this change:

Most of us integrators aren't waiting for OCA pull requests to integrate
them in our projects.
For this reason, we are using various tools to aggregate pull requests
such as [git-aggregator](https://github.com/acsone/git-aggregator) and
merge them into a consolidated branch.

Having merge conflicts in `test-requirements.txt` is not interesting in
this case, as it is only used by the OCA CI in order to avoid merging
pull requests that are depending on other unmerged pull requests.

Also, this is safe, as the CI prevents the merge of pull requests
introducing changes into this file.

I also would like to introduce this change on other repositories.

ping @sbidoul @gurneyalex 