### PR TITLE
[IMP] bump maintainer tools to the latest version

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -9,7 +9,7 @@
   {%- set repo_rev.flake8 = "5.0.0" %}
   {%- set repo_rev.flake8_bugbear = "20.1.4" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "d5fab7ee87fceee858a3d01048c78a548974d935" %}
+  {%- set repo_rev.maintainer_tools = "f9b919b9868143135a9c9cb03021089cabba8223" %}
   {%- set repo_rev.nodejs = "14.13.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
   {%- set repo_rev.pre_commit_hooks = "v3.2.0" %}
@@ -27,7 +27,7 @@
   {%- set repo_rev.flake8 = "5.0.0" %}
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "d5fab7ee87fceee858a3d01048c78a548974d935" %}
+  {%- set repo_rev.maintainer_tools = "f9b919b9868143135a9c9cb03021089cabba8223" %}
   {%- set repo_rev.nodejs = "14.18.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
   {%- set repo_rev.pre_commit_hooks = "v4.0.1" %}
@@ -45,7 +45,7 @@
   {%- set repo_rev.flake8 = "5.0.0" %}
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "d5fab7ee87fceee858a3d01048c78a548974d935" %}
+  {%- set repo_rev.maintainer_tools = "f9b919b9868143135a9c9cb03021089cabba8223" %}
   {%- set repo_rev.nodejs = "16.17.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
   {%- set repo_rev.pre_commit_hooks = "v4.3.0" %}
@@ -62,7 +62,7 @@
   {%- set repo_rev.flake8 = "3.9.2" %}
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "d5fab7ee87fceee858a3d01048c78a548974d935" %}
+  {%- set repo_rev.maintainer_tools = "f9b919b9868143135a9c9cb03021089cabba8223" %}
   {%- set repo_rev.nodejs = "16.17.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
   {%- set repo_rev.pre_commit_hooks = "v4.3.0" %}


### PR DESCRIPTION
Why? Because there are a lot of changes that are not reflected properly and may create a mess if different maintainer tools versions are used in OCA bot and repo template.
For example, in one of the commits we rename 'licence' into 'license'. But because pre-commit is pinned to the commit before this change it is renaming it back again and again making the commit history dirty. And although this was not yet spotted in the OCA repos, some other repos using OCA tools are affected.