### PR TITLE
[FIX] run all github actions on ubuntu 22.04

### DIFF
--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -11,11 +11,7 @@ on:
 
 jobs:
   pre-commit:
-{%- if odoo_version < 14 %}
-    runs-on: ubuntu-20.04
-{%- else %}
     runs-on: ubuntu-22.04
-{%- endif %}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -24,7 +20,7 @@ jobs:
           python-version: "2.7"
 {%- elif odoo_version < 13 %}
         with:
-          python-version: "3.6"
+          python-version: "3.7"
 {%- elif odoo_version < 14 %}
         with:
           python-version: "3.8"

--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -72,11 +72,7 @@ jobs:
               fi
           done
   test:
-{%- if odoo_version < 14 %}
-    runs-on: ubuntu-20.04
-{%- else %}
     runs-on: ubuntu-22.04
-{%- endif %}
     container: {% raw %}${{ matrix.container }}{% endraw %}
     name: {% raw %}${{ matrix.name }}{% endraw %}
     strategy:

--- a/version-specific/mqt-compat/.pre-commit-config.yaml.jinja
+++ b/version-specific/mqt-compat/.pre-commit-config.yaml.jinja
@@ -15,7 +15,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3.6
+  python: python3
 repos:
   - repo: https://github.com/oca/maintainer-tools
     rev: ab1d7f6


### PR DESCRIPTION
*   use ubuntu 22.04 for all github actions instead of using ubuntu 20.04 for versions < 14, as ubuntu 20.04 has been retired by github.
*   use python 3.7 (instead of 3.6) for pre-commit, as this is the minimal available version on github's ubuntu 22.04 environment.