### PR TITLE
[IMP] upload screenshots as artifacts if they exist and tests fail

### DIFF
--- a/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if ci == 'GitHub' %}test.yml{% endif %}.jinja
@@ -160,6 +160,13 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
+      - name: Upload screenshots from JS tests
+        uses: actions/upload-artifact@v4
+        if: {{"${{ failure() }}"}}
+        with:
+          name: Screenshots of failed JS tests - {{"${{ matrix.name }}${{ join(matrix.include) }}"}}
+          path: /tmp/odoo_tests/{{"${{ env.PGDATABASE }}"}}
+          if-no-files-found: ignore
       {%- if github_enable_codecov %}
       - uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
given this only runs on test failures and doesn't do anything if there are no screenshots, I think it can be unconditional.

You can check out how this looks [here](https://github.com/OCA/crowdfunding/actions/runs/17851749903/job/50761657310?pr=6#step:9:1) and [here](https://github.com/OCA/crowdfunding/actions/runs/17851749903?pr=6) (scroll down to artifacts), was already helpful in that case.