### PR TITLE
[FIX] Set python minor version on pre-commit

### DIFF
--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -1,3 +1,4 @@
+{% from 'src/.pre-commit-config.yaml.jinja' import repo_rev with context %}
 name: pre-commit
 
 on:
@@ -26,7 +27,7 @@ jobs:
           python-version: "3.8"
 {%- else %}
         with:
-          python-version: "3.11"
+          python-version: "{{ repo_rev.python |replace('python','') }}"
 {%- endif %}
           cache: 'pip'
           cache-dependency-path: '.pre-commit-config.yaml'

--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -20,6 +20,7 @@
   {%- set repo_rev.pyupgrade = "v2.7.2" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
+  {%- set repo_rev.python = "python3.8" %}
 {%- elif odoo_version < 16 %}
   {%- set repo_rev.autoflake = "v1.5.3" %}
   {%- set repo_rev.black = "22.3.0" %}
@@ -38,6 +39,7 @@
   {%- set repo_rev.pyupgrade = "v2.29.0" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
+  {%- set repo_rev.python = "python3.8" %}
 {%- elif odoo_version < 17 %}
   {%- set repo_rev.autoflake = "v1.6.1" %}
   {%- set repo_rev.black = "22.8.0" %}
@@ -55,6 +57,7 @@
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
+  {%- set repo_rev.python = "python3.10" %}
 {%- elif odoo_version < 18 %}
   {%- set repo_rev.autoflake = "v1.6.1" %}
   {%- set repo_rev.black = "22.8.0" %}
@@ -72,6 +75,7 @@
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
+  {%- set repo_rev.python = "python3.10" %}
 {%- elif odoo_version < 19 %}
   {%- set repo_rev.autoflake = "v1.6.1" %}
   {%- set repo_rev.black = "22.8.0" %}
@@ -91,6 +95,7 @@
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
   {%- set repo_rev.ruff = "v0.6.8" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
+  {%- set repo_rev.python = "python3.12" %}
 {%- else %}
   {%- set repo_rev.autoflake = "v2.3.1" %}
   {%- set repo_rev.black = "25.1.0" %}
@@ -110,6 +115,7 @@
   {%- set repo_rev.pyupgrade = "v3.20.0" %}
   {%- set repo_rev.ruff = "v0.13.0" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
+  {%- set repo_rev.python = "python3.12" %}
 {%- endif %}
 
 {#- Older versions that differ a lot have their own hardcoded templates for readability #}
@@ -144,7 +150,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: {{ repo_rev.python }}
   node: "{{ repo_rev.nodejs }}"
 repos:
   - repo: local


### PR DESCRIPTION
I was having issues with flake on 16.0, because it was using pythyon 3.13 and it seems to be incompatible with the current config. This sets the python version to the same used to run CI to avoid this problem.

@Tecnativa