### PR TITLE
[IMP] pre-commit: Add refurb

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -141,6 +141,14 @@ additional_ruff_rules:
   help: List of additional ruff rules to enable.
   when: "{{ use_ruff }}"
 
+use_refurb:
+  default: "{% if odoo_version < 20.0 -%}no{% else %}yes{% endif %}"
+  type: bool
+  help:
+    Use refurb (https://github.com/dosisod/refurb) for refurbishing and modernizing
+    Python codebase.
+  when: "{{ odoo_version >= 14.0 }}"
+
 rebel_module_groups:
   type: yaml
   default: []

--- a/copier.yml
+++ b/copier.yml
@@ -100,6 +100,14 @@ additional_ruff_rules:
   help: List of additional ruff rules to enable.
   when: "{{ use_ruff }}"
 
+use_refurb:
+  default: "{% if odoo_version < 20.0 -%}no{% else %}yes{% endif %}"
+  type: bool
+  help:
+    Use refurb (https://github.com/dosisod/refurb) for refurbishing and modernizing
+    Python codebase.
+  when: "{{ odoo_version >= 14.0 }}"
+
 rebel_module_groups:
   type: yaml
   default: []

--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -18,6 +18,7 @@
   {%- set repo_rev.pylint = "v2.11.1" %}
   {%- set repo_rev.pylint_odoo = "7.0.2" %}
   {%- set repo_rev.pyupgrade = "v2.7.2" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
 {%- elif odoo_version < 16 %}
@@ -36,6 +37,7 @@
   {%- set repo_rev.pylint = "v2.11.1" %}
   {%- set repo_rev.pylint_odoo = "7.0.5" %}
   {%- set repo_rev.pyupgrade = "v2.29.0" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
 {%- elif odoo_version < 17 %}
@@ -53,6 +55,7 @@
   {%- set repo_rev.prettier_xml = "2.2.0" %}
   {%- set repo_rev.pylint_odoo = "v8.0.19" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
 {%- elif odoo_version < 18 %}
@@ -70,6 +73,7 @@
   {%- set repo_rev.prettier_xml = "2.2.0" %}
   {%- set repo_rev.pylint_odoo = "v9.0.4" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
 {%- elif odoo_version < 19 %}
@@ -89,6 +93,7 @@
   {%- set repo_rev.prettier_xml = "3.4.1" %}
   {%- set repo_rev.pylint_odoo = "v9.1.3" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.6.8" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
 {%- else %}
@@ -108,6 +113,7 @@
   {%- set repo_rev.prettier_xml = "3.4.2" %}
   {%- set repo_rev.pylint_odoo = "v9.3.15" %}
   {%- set repo_rev.pyupgrade = "v3.20.0" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.13.0" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
 {%- endif %}
@@ -297,6 +303,13 @@ repos:
           - --header
           - "# generated from manifests external_dependencies"
       {%- endif %}
+  {%- endif %}
+  {%- if use_refurb %}
+  - repo: https://github.com/dosisod/refurb
+    rev: {{ repo_rev.refurb }}
+    hooks:
+      - id: refurb
+        exclude: migrations/.*
   {%- endif %}
   {%- if not use_ruff %}
   - repo: https://github.com/PyCQA/flake8

--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -18,6 +18,7 @@
   {%- set repo_rev.pylint = "v2.11.1" %}
   {%- set repo_rev.pylint_odoo = "7.0.2" %}
   {%- set repo_rev.pyupgrade = "v2.7.2" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
   {%- set repo_rev.python = "python3.8" %}
@@ -37,6 +38,7 @@
   {%- set repo_rev.pylint = "v2.11.1" %}
   {%- set repo_rev.pylint_odoo = "7.0.5" %}
   {%- set repo_rev.pyupgrade = "v2.29.0" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
   {%- set repo_rev.python = "python3.8" %}
@@ -55,6 +57,7 @@
   {%- set repo_rev.prettier_xml = "2.2.0" %}
   {%- set repo_rev.pylint_odoo = "v8.0.19" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
   {%- set repo_rev.python = "python3.10" %}
@@ -73,6 +76,7 @@
   {%- set repo_rev.prettier_xml = "2.2.0" %}
   {%- set repo_rev.pylint_odoo = "v9.0.4" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.1.3" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
   {%- set repo_rev.python = "python3.10" %}
@@ -93,6 +97,7 @@
   {%- set repo_rev.prettier_xml = "3.4.1" %}
   {%- set repo_rev.pylint_odoo = "v9.1.3" %}
   {%- set repo_rev.pyupgrade = "v2.38.2" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.6.8" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
   {%- set repo_rev.python = "python3.12" %}
@@ -113,6 +118,7 @@
   {%- set repo_rev.prettier_xml = "3.4.2" %}
   {%- set repo_rev.pylint_odoo = "v10.0.8" %}
   {%- set repo_rev.pyupgrade = "v3.20.0" %}
+  {%- set repo_rev.refurb = "v2.3.1" %}
   {%- set repo_rev.ruff = "v0.13.0" %}
   {%- set repo_rev.setuptools_odoo = "3.3.2" %}
   {%- set repo_rev.python = "python3.12" %}
@@ -308,6 +314,13 @@ repos:
           - --header
           - "# generated from manifests external_dependencies"
       {%- endif %}
+  {%- endif %}
+  {%- if use_refurb %}
+  - repo: https://github.com/dosisod/refurb
+    rev: {{ repo_rev.refurb }}
+    hooks:
+      - id: refurb
+        exclude: migrations/.*
   {%- endif %}
   {%- if not use_ruff %}
   - repo: https://github.com/PyCQA/flake8


### PR DESCRIPTION
Refurb (https://github.com/dosisod/refurb) is:
> A tool for refurbishing and modernizing Python codebases.

This PR proposes to add it as a `pre-commit`  check for repositories, default for future versions.

The `migrations` folder is excluded because it raises an error like:
```
l10n_it_account_stamp/migrations/18.0.1.0.0/post-migration.py: error: Duplicate module named "post-migration" (also at "l10n_it_account/migrations/18.0.1.0.0/post-migration.py")
l10n_it_account_stamp/migrations/18.0.1.0.0/post-migration.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info
l10n_it_account_stamp/migrations/18.0.1.0.0/post-migration.py: note: Common resolutions include: a) using `--exclude` to avoid checking one of them, b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or adjusting MYPYPATH
```
Excluding them is a small price to pay, to have the whole rest of the codebase improved in my opinion.

Let me know what you think!