### PR TITLE
[ADD] postgis_extension copier flag for geo-dependent OCA repos

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -114,6 +114,18 @@ include_wkhtmltopdf:
     Do you need to install wkhtmltopdf? Usually only needed if you're going to test PDF
     report generation.
 
+postgis_extension:
+  type: bool
+  default: no
+  when: "{{ odoo_version >= 16 }}"
+  help:
+    Does this repo install Odoo modules that require the PostGIS extension
+    (geo_* field types, wkb_geometry columns, base_geoengine, etc.)?
+    When yes, the CI postgres service uses a postgis/postgis:<pg>-<postgis>
+    image so pre_init_hook CREATE EXTENSION postgis succeeds. Recommended
+    for OCA/geospatial and any repo with geo fields. Available for
+    odoo_version >= 16.0 (postgis/postgis:9.6-* tags are EOL).
+
 enable_checklog_odoo:
   type: bool
   default: "{% if odoo_version < 18.0 -%}no{% else %}yes{% endif %}"

--- a/src/.github/workflows/test.yml.jinja
+++ b/src/.github/workflows/test.yml.jinja
@@ -121,12 +121,30 @@ jobs:
         {%- endif %}
     services:
       postgres:
+        {%- if postgis_extension and odoo_version >= 16 %}
+        # PostGIS image variants ship the spatial extension preinstalled so
+        # modules with geo_* fields can `CREATE EXTENSION postgis` in their
+        # pre_init_hook. Image tags chosen to match the OCA/geospatial
+        # baseline on each Odoo series:
+        #   16-18  -> postgis/postgis:13-3.4 (already ships on OCA/geospatial
+        #            17.0 + 18.0 branches)
+        #   >= 19  -> postgis/postgis:14-3.5 (matches OCA/geospatial PR #446)
+        # Both PG versions are within Odoo's documented PG support window.
+        # Flag is gated to odoo_version >= 16 because postgis/postgis:9.6-*
+        # tags are EOL and not maintained.
+        {%- if odoo_version < 19 %}
+        image: postgis/postgis:13-3.4
+        {%- else %}
+        image: postgis/postgis:14-3.5
+        {%- endif %}
+        {%- else %}
         {%- if odoo_version < 16 %}
         image: postgres:9.6
         {%- elif odoo_version < 19 %}
         image: postgres:12
         {%- else %}
         image: postgres:13
+        {%- endif %}
         {%- endif %}
         env:
           POSTGRES_USER: odoo


### PR DESCRIPTION
## Why

OCA/geospatial 17.0 and 18.0 already ship `postgis/postgis:13-3.4` as their CI postgres service so `CREATE EXTENSION postgis` succeeds at module install time. Every `copier update` wipes that override because the vanilla template hardcodes `postgres:*`, so every cohort PR has to re-patch `.github/workflows/test.yml` and defend it as in-scope. See [OCA/geospatial#446](https://github.com/OCA/geospatial/pull/446) for the canonical example of a workflow-change defense thread.

This flag makes the override declarative — set `postgis_extension: yes` once in the repo's `copier-answers.yml`, and the workflow regenerates with the right image on every future `copier update`. Eliminates a recurring toil for geospatial-flavored OCA repos.

## What

- New `copier.yml` boolean `postgis_extension`, default `no`, gated to `odoo_version >= 16` (postgis/postgis:9.6-* tags are EOL).
- Conditional in `src/.github/workflows/test.yml.jinja` that swaps `postgres:*` → `postgis/postgis:<pg>-<postgis>` when the flag is on:
  - `16 ≤ odoo < 19` → `postgis/postgis:13-3.4` (matches OCA/geospatial 17.0 + 18.0 baseline)
  - `odoo ≥ 19` → `postgis/postgis:14-3.5` (matches the choice in OCA/geospatial#446)

Both PG versions are inside [Odoo's documented PostgreSQL support window](https://www.odoo.com/documentation/19.0/administration/install.html) (Odoo 17/18 → PG 12-16, Odoo 19 → PG 13-17).

## Validation

Aggregated the OCA/geospatial 19.0 cohort (#446 + #450 + #451 + #452 + #453) onto a single branch on the ledoent fork and ran CI with the equivalent workflow change:

https://github.com/ledoent/geospatial/actions/runs/26052247018

All three jobs pass green with `postgis/postgis:14-3.5` driving install + tests for `base_geoengine` + `geoengine_partner` + `geoengine_base_geolocalize` + `website_geoengine` + `website_geoengine_store_locator`:

| Job | Result | Time |
|---|---|---|
| `test with Odoo` | ✓ pass | 1m30s |
| `test with OCB` | ✓ pass | 1m36s |
| `Detect unreleased dependencies` | ✓ pass | 5s |

## Backwards compatibility

`default: no` — repos that don't opt in see **zero diff** on their next `copier update`. The vanilla `postgres:*` images stay exactly as today for every existing OCA repo. Only repos that explicitly set `postgis_extension: yes` (today: OCA/geospatial; in the future: any geo-flavored OCA repo) get the postgis variant.