### PR TITLE
Bump maintainer-tools pin to current master (gen-addon-readme HTML title + OCA hook fixes)

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -9,7 +9,7 @@
   {%- set repo_rev.flake8 = "5.0.0" %}
   {%- set repo_rev.flake8_bugbear = "20.1.4" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "f9b919b9868143135a9c9cb03021089cabba8223" %}
+  {%- set repo_rev.maintainer_tools = "31bdbd8e4cb94be6534f0e82b1cafb84a455f671" %}
   {%- set repo_rev.nodejs = "14.13.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
   {%- set repo_rev.pre_commit_hooks = "v3.2.0" %}
@@ -28,7 +28,7 @@
   {%- set repo_rev.flake8 = "5.0.0" %}
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "f9b919b9868143135a9c9cb03021089cabba8223" %}
+  {%- set repo_rev.maintainer_tools = "31bdbd8e4cb94be6534f0e82b1cafb84a455f671" %}
   {%- set repo_rev.nodejs = "14.18.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
   {%- set repo_rev.pre_commit_hooks = "v4.0.1" %}
@@ -47,7 +47,7 @@
   {%- set repo_rev.flake8 = "5.0.0" %}
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "f9b919b9868143135a9c9cb03021089cabba8223" %}
+  {%- set repo_rev.maintainer_tools = "31bdbd8e4cb94be6534f0e82b1cafb84a455f671" %}
   {%- set repo_rev.nodejs = "16.17.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
   {%- set repo_rev.pre_commit_hooks = "v4.3.0" %}
@@ -65,7 +65,7 @@
   {%- set repo_rev.flake8 = "3.9.2" %}
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "f9b919b9868143135a9c9cb03021089cabba8223" %}
+  {%- set repo_rev.maintainer_tools = "31bdbd8e4cb94be6534f0e82b1cafb84a455f671" %}
   {%- set repo_rev.nodejs = "16.17.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.25" %}
   {%- set repo_rev.pre_commit_hooks = "v4.3.0" %}
@@ -85,7 +85,7 @@
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.globals = "16.0.0" %}
   {%- set repo_rev.isort = "5.12.0" %}
-  {%- set repo_rev.maintainer_tools = "b89f767503be6ab2b11e4f50a7557cb20066e667" %}
+  {%- set repo_rev.maintainer_tools = "31bdbd8e4cb94be6534f0e82b1cafb84a455f671" %}
   {%- set repo_rev.nodejs = "22.9.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.0.33" %}
   {%- set repo_rev.pre_commit_hooks = "v4.6.0" %}
@@ -105,7 +105,7 @@
   {%- set repo_rev.flake8_bugbear = "21.9.2" %}
   {%- set repo_rev.globals = "16.0.0" %}
   {%- set repo_rev.isort = "6.0.1" %}
-  {%- set repo_rev.maintainer_tools = "f9b919b9868143135a9c9cb03021089cabba8223" %}
+  {%- set repo_rev.maintainer_tools = "31bdbd8e4cb94be6534f0e82b1cafb84a455f671" %}
   {%- set repo_rev.nodejs = "22.9.0" %}
   {%- set repo_rev.odoo_pre_commit_hooks = "v0.1.7" %}
   {%- set repo_rev.pre_commit_hooks = "v6.0.0" %}


### PR DESCRIPTION
Bumps the pinned `maintainer-tools` rev from `f9b919b` (2025-06-03) to current master `31bdbd8` (2026-05-21)
