### PR TITLE
[FIX] .pylintrc: drop duplicated comma before optional checks on 15.0-18.0

### DIFF
--- a/src/.pylintrc.jinja
+++ b/src/.pylintrc.jinja
@@ -15,7 +15,7 @@
     missing-manifest-dependency,
     too-complex,
 {%- endif %}
-{%- if odoo_version >= 15 and odoo_version <= 18 %},
+{%- if odoo_version >= 15 and odoo_version <= 18 %}
     create-user-wo-reset-password,
     dangerous-filter-wo-user,
     file-not-used,


### PR DESCRIPTION
Fixes the double comma rendered into `.pylintrc` right after `too-complex` on Odoo 15.0–18.0.

Closes #337
