### PR TITLE
Cancel in-progress CI runs on new pushes to the same branch

### DIFF
--- a/src/.github/workflows/pre-commit.yml.jinja
+++ b/src/.github/workflows/pre-commit.yml.jinja
@@ -10,6 +10,10 @@ on:
       - "{{ odoo_version }}"
       - "{{ odoo_version }}-ocabot-*"
 
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04

--- a/src/.github/workflows/test.yml.jinja
+++ b/src/.github/workflows/test.yml.jinja
@@ -9,6 +9,10 @@ on:
       - "{{ odoo_version }}"
       - "{{ odoo_version }}-ocabot-*"
 
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
 {%
 set IMAGES = {
   "odoo": {


### PR DESCRIPTION
Adds a `concurrency` group with `cancel-in-progress: true` to the generated `test.yml` and `pre-commit.yml` so successive pushes to the same branch/PR cancel the previous still-running jobs

Closes #125
