### PR TITLE
[REF] pylintrc-mandatory: enable deprecated module checks

### DIFF
--- a/src/.pylintrc-mandatory.jinja
+++ b/src/.pylintrc-mandatory.jinja
@@ -5,6 +5,9 @@
 load-plugins=pylint_odoo
 score=n
 
+[IMPORTS]
+deprecated-modules=pdb,pudb,ipdb,bs4{%- if odoo_version >= 20 %},pytz{%- endif %}
+
 [ODOOLINT]
 {%- if odoo_version < 16 %}
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
@@ -46,6 +49,7 @@ enable=anomalous-backslash-in-string,
     assignment-from-none,
     attribute-deprecated,
     dangerous-default-value,
+    deprecated-module,
     development-status-allowed,
     duplicate-key,
     eval-used,

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -50,11 +50,21 @@ def test_bootstrap(tmp_path: Path, odoo_version: float, cloned_template: Path):
         # underscores
         valid_odoo_versions = "valid-odoo-versions"
     assert f"{valid_odoo_versions}={odoo_version}" in pylintrc_mandatory
+    if odoo_version >= 13:
+        expected_deprecated_modules = "pdb,pudb,ipdb,bs4"
+        if odoo_version >= 20:
+            expected_deprecated_modules += ",pytz"
+        assert "[IMPORTS]" in pylintrc_mandatory
+        assert f"deprecated-modules={expected_deprecated_modules}" in pylintrc_mandatory
+        assert "deprecated-module," in pylintrc_mandatory
     assert SOME_PYLINT_OPTIONAL_CHECK not in pylintrc_mandatory
     pylintrc_optional = (tmp_path / ".pylintrc").read_text()
     assert "disable=all\n" in pylintrc_optional
     assert "# This .pylintrc contains" in pylintrc_optional
     assert f"{valid_odoo_versions}={odoo_version}" in pylintrc_optional
+    if odoo_version >= 13:
+        assert f"deprecated-modules={expected_deprecated_modules}" in pylintrc_optional
+        assert "deprecated-module," in pylintrc_optional
     assert SOME_PYLINT_OPTIONAL_CHECK in pylintrc_optional
     if odoo_version < 17:
         flake8 = (tmp_path / ".flake8").read_text()


### PR DESCRIPTION
Enable pylint's deprecated-module check in the mandatory rcfile used by the blocking pre-commit hook for Odoo 13.0 and newer.

This makes generated OCA repositories fail fast when forbidden imports such as pdb, pudb, ipdb, or bs4 are introduced, instead of leaving the check only in the optional IDE-oriented pylint configuration.

For Odoo 20.0 and newer, also mark pytz as deprecated so repositories generated from this template follow the upstream direction taken in Odoo saas-19.1.

That branch removed pytz usage in Odoo commit:
 - https://github.com/odoo/odoo/commit/6fdb36716aac5d2b084fb0faa94ccb2f3ee7f99c

Keep the scope limited to 13.0+ templates, where src/.pylintrc-mandatory.jinja is the source used to render both .pylintrc-mandatory and the inherited optional .pylintrc. Legacy <=12.0 templates are intentionally left unchanged.

Extend the bootstrap test to assert the rendered [IMPORTS] section and the version-specific pytz addition.