### PR TITLE
[FIX] prettier 3.x: actually use plugin-xml

### DIFF
--- a/src/.pre-commit-config.yaml.jinja
+++ b/src/.pre-commit-config.yaml.jinja
@@ -227,8 +227,20 @@ repos:
     hooks:
       - id: prettier
         name: prettier (with plugin-xml)
+        {%- if odoo_version >= 18 %}
+        # hack: prettier version 3.x doesn't auto search for plugins, we need to pass
+        # them explicitly
+        entry:
+          bash -c "prettier --plugin=$NODE_PATH/@prettier/plugin-xml/src/plugin.js $0
+          $*"
+        {%- else %}
         entry: prettier
+        {%- endif %}
         args:
+        {%- if odoo_version < 18 %}
+          - --plugin=@prettier/plugin-xml
+        {%- endif %}
+          - --xml-whitespace-sensitivity=strict
           - --write
           - --list-different
           - --ignore-unknown

--- a/tests/test_pre_commit.py
+++ b/tests/test_pre_commit.py
@@ -17,3 +17,14 @@ def test_hooks_installable(tmp_path: Path, odoo_version: float, cloned_template:
     with local.cwd(tmp_path):
         git("init")
         pre_commit("install-hooks")
+        Path("test.xml").write_text(
+            '<?xml version="1.0" encoding="utf-8" ?>\n'
+            '<root><should    be="formatted" /></root>'
+        )
+        git("add", "test.xml")
+        pre_commit("run", "prettier", retcode=1)
+        formatted = (
+            '<?xml version="1.0" encoding="utf-8" ?>\n'
+            '<root><should be="formatted" /></root>\n'
+        )
+        assert Path("test.xml").read_text() == formatted


### PR DESCRIPTION
while working on formatting some xml files, I noticed that prettier doesn't actually load plugin-xml in versions 3.x. You can check this by adding `--xml-whitespace-sensitivity=strict` to args, this will fail with the current configuration.

This seems to be https://github.com/prettier/prettier/issues/15085

Note that this will cause large scale reformatting on existing files, because the html formatter that's used otherwise formats xml slightly differently (which is why we want plugin-xml in the first place though)

@yajo I've seen you've worked on this before, what is your conclusion here?