### PR TITLE
[IMP] checklog-odoo: ignore warning about website.list_hybrid in search

### DIFF
--- a/src/{% if enable_checklog_odoo %}checklog-odoo.cfg{% endif %}
+++ b/src/{% if enable_checklog_odoo %}checklog-odoo.cfg{% endif %}
@@ -3,3 +3,4 @@ ignore=
     WARNING.* 0 failed, 0 error\(s\).*
     WARNING .* Killing chrome descendants-or-self .*
     WARNING.* Missing widget: res_partner_many2one for field of type many2one.*
+    WARNING.* Unknown directives or unused attributes: {'t-key'} in website.list_hybrid.*


### PR DESCRIPTION
Searching on the website emits a [warning](https://github.com/OCA/crowdfunding/actions/runs/29084229112/job/86334020547?pr=25#step:8:395) because of the t-key attribute in https://github.com/OCA/OCB/blob/18.0/addons/website/views/website_templates.xml#L2738.

Won't be fixed in upstream as of https://github.com/odoo/odoo/pull/179017#issuecomment-4934713678, so we need to ignore this to be able to test anything involving the search frontend