### PR TITLE
[IMP] use check-vendor-libs action

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -160,3 +160,11 @@ github_ci_extra_env:
 convert_readme_fragments_to_markdown:
   default: "{% if odoo_version < 17.0 -%}no{% else %}yes{% endif %}"
   type: bool
+
+use_check_vendor_libs:
+  default: "{% if odoo_version < 18.0 -%}disabled{% elif odoo_version < 20.0 %}optional{% else %}mandatory{% endif %}"
+  choices:
+    - disabled
+    - optional
+    - mandatory
+  help: Verify vendored javascript code

--- a/src/.github/workflows/{% if use_check_vendor_libs != "disabled" %}check-vendor-libs.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if use_check_vendor_libs != "disabled" %}check-vendor-libs.yml{% endif %}.jinja
@@ -1,0 +1,29 @@
+name: Verify vendored javascript code
+
+on:
+  pull_request:
+    branches:
+      - "{{ odoo_version }}*"
+    paths:
+      - "*/static/lib/**"
+  push:
+    branches:
+      - "{{ odoo_version }}"
+      - "{{ odoo_version }}-ocabot-*"
+
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
+jobs:
+  check_vendor_libs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check vendor libs
+        uses: hbrunn/check-vendor-libs@v1
+        with:
+          directories: "*/static/lib"
+          {%- if use_check_vendor_libs == 'optional' %}
+          no_fail: true
+          {%- endif %}


### PR DESCRIPTION
This adds [hbrunn/check-vendor-libs](https://github.com/hbrunn/check-vendor-libs#introduction) as discussed in https://github.com/OCA/odoo-pre-commit-hooks/issues/191.

When applied to the website repository:

- [optional](https://github.com/hbrunn/website/actions/runs/30636350411)
- [mandatory](https://github.com/hbrunn/website/actions/runs/30636562350)
- [mandatory with declared origin](https://github.com/hbrunn/website/actions/runs/30637845849) (the [commit](https://github.com/hbrunn/website/commit/09264b708fef8c9221bd1ec42ff682bdf4d9448b) declaring origin and fixing small divergences)
- [mandatory with declared origin](https://github.com/hbrunn/website/actions/runs/30639135137/job/91184297234), introducing a [deviation](https://github.com/hbrunn/website/commit/7f145cc9e31d80b14819671a06beaadfa76df183)

I think this should be mandatory for all v20+ repositories so that people can take care of this when migrating to that version and hopefully updating the vendored code anyways. I set the default to disabled for <18 because I don't expect anyone to care for those versions enough to add it there.